### PR TITLE
feat: add save and load functionality

### DIFF
--- a/index.html
+++ b/index.html
@@ -15,6 +15,9 @@
 <body>
   <div id="ui">
     <div class="panel" id="stats"></div>
+    <button id="saveBtn" class="panel">Save</button>
+    <button id="loadBtn" class="panel">Load</button>
+    <input id="loadInput" type="file" accept=".txt" class="hidden" />
   </div>
   <canvas id="game" width="1280" height="720"></canvas>
   <div id="toasts" class="fixed top-4 right-4 z-30 space-y-2 pointer-events-none"></div>

--- a/js/main.js
+++ b/js/main.js
@@ -1,8 +1,9 @@
 import {TILE, MAP_W, MAP_H, MOVE_ACC, MAX_HSPEED, GRAV, FRICTION} from './config.js';
 import {MATERIALS} from './materials.js';
 import {world, worldToTile, isSolidAt} from './world.js';
-import {canvas, ctx, statsEl, say, closeAllModals, isUIOpen, openInventory, openShop, openMarket, renderMarket, marketModal} from './ui.js';
+import {canvas, ctx, statsEl, say, closeAllModals, isUIOpen, openInventory, openShop, openMarket, renderMarket, marketModal, saveBtn, loadBtn, loadInput} from './ui.js';
 import {player, buildings, rectsIntersect, totalWeight, invAdd, teleportHome, upgrades, priceFor, buy, sellItem, sellAll, inventoryValue} from './player.js';
+import {saveGameToFile, loadGameFromString} from './save.js';
 
 const keys = new Set();
 let mouse = { down: false };
@@ -127,3 +128,17 @@ function fit() {
   canvas.height = Math.floor(innerHeight * dpr);
 }
 addEventListener('resize', fit); fit();
+
+saveBtn.onclick = () => { saveGameToFile(); say('Game saved'); };
+loadBtn.onclick = () => loadInput.click();
+loadInput.onchange = e => {
+  const file = e.target.files[0];
+  if (!file) return;
+  const reader = new FileReader();
+  reader.onload = () => {
+    if (loadGameFromString(reader.result)) say('Game loaded');
+    else say('Failed to load save');
+  };
+  reader.readAsText(file);
+  loadInput.value = '';
+};

--- a/js/save.js
+++ b/js/save.js
@@ -1,0 +1,44 @@
+import { player, buildings } from './player.js';
+import { world } from './world.js';
+
+export function serializeGame() {
+  const state = {
+    player,
+    buildings,
+    world: Array.from(world.tiles)
+  };
+  return btoa(JSON.stringify(state));
+}
+
+export function saveGameToFile() {
+  const data = serializeGame();
+  const blob = new Blob([data], { type: 'text/plain' });
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement('a');
+  a.href = url;
+  a.download = 'raksmine-save.txt';
+  document.body.appendChild(a);
+  a.click();
+  document.body.removeChild(a);
+  URL.revokeObjectURL(url);
+}
+
+export function loadGameFromString(b64) {
+  try {
+    const json = atob(b64.trim());
+    const state = JSON.parse(json);
+    Object.assign(player, state.player);
+    player.inventory = state.player.inventory || [];
+    buildings.length = 0;
+    if (Array.isArray(state.buildings)) {
+      for (const b of state.buildings) buildings.push(b);
+    }
+    if (Array.isArray(state.world) && state.world.length === world.tiles.length) {
+      world.tiles.set(state.world);
+    }
+    return true;
+  } catch (e) {
+    console.error('Failed to load game', e);
+    return false;
+  }
+}

--- a/js/ui.js
+++ b/js/ui.js
@@ -9,6 +9,9 @@ const invGrid = document.getElementById('invGrid');
 export const marketModal = document.getElementById('marketModal');
 const marketBody = document.getElementById('marketBody');
 const marketTotal = document.getElementById('marketTotal');
+export const saveBtn = document.getElementById('saveBtn');
+export const loadBtn = document.getElementById('loadBtn');
+export const loadInput = document.getElementById('loadInput');
 
 document.getElementById('shopClose').onclick = () => closeAllModals();
 document.getElementById('invClose').onclick = () => closeAllModals();


### PR DESCRIPTION
## Summary
- Add save and load buttons to UI to export/import game progress
- Implement serialization to base64 and file download/upload handlers
- Wire up handlers in main loop for full game state persistence

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6895f7e223b0833080264d67af3968de