### PR TITLE
Add lung expansion and drill upgrades

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -29,10 +29,19 @@ function tryMine() {
   else if (lastDir === 'left') dx = -1; else if (lastDir === 'right') dx = 1;
   const cx = player.x + player.w / 2, cy = player.y + player.h / 2;
   const { tx, ty } = worldToTile(cx, cy);
-  const id = world.get(tx + dx, ty + dy); if (id <= 0) return;
-  const m = MATERIALS[id];
-  const cost = 3 + m.hard; if (m.hard > player.pickPower || player.stamina < cost) return;
-  world.set(tx + dx, ty + dy, 0); player.stamina -= cost; invAdd(id, 1); if (dy === 1) player.vy = Math.max(player.vy, 0.5);
+  let mined = false;
+  for (let i = 1; i <= player.drill; i++) {
+    const id = world.get(tx + dx * i, ty + dy * i);
+    if (id <= 0) continue;
+    const m = MATERIALS[id];
+    const cost = 3 + m.hard;
+    if (m.hard > player.pickPower || player.stamina < cost) break;
+    world.set(tx + dx * i, ty + dy * i, 0);
+    player.stamina -= cost;
+    invAdd(id, 1);
+    mined = true;
+  }
+  if (mined && dy === 1) player.vy = Math.max(player.vy, 0.5);
 }
 
 function resolveCollisions() {
@@ -116,7 +125,7 @@ function draw() {
   ctx.fillStyle = '#f59e0b';
   ctx.fillRect(player.x - camera.x, player.y - camera.y, player.w, player.h);
 
-  statsEl.innerHTML = `Cash: $${player.cash} | Stamina: ${Math.floor(player.stamina)}/${player.staminaMax} | Weight: ${totalWeight()}/${player.carryCap} | Pick: ${player.pickPower} | Speed×${player.speed.toFixed(2)}`;
+  statsEl.innerHTML = `Cash: $${player.cash} | Stamina: ${Math.floor(player.stamina)}/${player.staminaMax} | Weight: ${totalWeight()}/${player.carryCap} | Pick: ${player.pickPower} | Drill: ${player.drill} | Speed×${player.speed.toFixed(2)}`;
 }
 
 function loop() { tick(); draw(); requestAnimationFrame(loop); }

--- a/js/player.js
+++ b/js/player.js
@@ -18,7 +18,8 @@ export const player = {
   staminaMax: 100,
   carryCap: 40,
   pickPower: 2,
-  speed: 1.0,
+  speed: 0.6,
+  drill: 1,
   inventory: []
 };
 
@@ -93,15 +94,18 @@ export function teleportHome() {
 }
 
 export const upgrades = {
-  pickaxe:  { key: 'pickPower', name: 'Pickaxe',           desc: 'Mine harder materials', step: 1,    max: 10,  base: 50,  scale: 1.6 },
-  boots:    { key: 'speed',     name: 'Boots',             desc: 'Move faster',          step: 0.10, max: 2.0, base: 80,  scale: 1.5 },
-  backpack: { key: 'carryCap',  name: 'Leather Backpack',  desc: 'Increase carry cap',   step: 20,   max: 300, base: 60,  scale: 1.45 },
+  pickaxe:  { key: 'pickPower', name: 'Pickaxe',           desc: 'Mine harder materials', step: 1,    max: 10,  base: 50,  scale: 1.6,  baseLevel: 0 },
+  boots:    { key: 'speed',     name: 'Boots',             desc: 'Move faster',          step: 0.10, max: 2.0, base: 80,  scale: 1.5,  baseLevel: 0.6 },
+  backpack: { key: 'carryCap',  name: 'Leather Backpack',  desc: 'Increase carry cap',   step: 20,   max: 300, base: 60,  scale: 1.45, baseLevel: 0 },
+  lungs:    { key: 'staminaMax', name: 'Lung Expansion Pills', desc: 'Increase stamina',   step: 20,   max: Infinity, baseLevel: 100, price: level => 150 * Math.pow(level + 1, 1.3) },
+  drill:    { key: 'drill',     name: 'Drill Expander',    desc: 'Mine more blocks',     step: 1,    max: 5,      baseLevel: 1,    price: level => (level + 1) * 500 }
 };
 
 export function priceFor(u) {
   const cur = player[u.key];
-  const baseLevel = u.key === 'speed' ? 1.0 : 0.0;
+  const baseLevel = u.baseLevel !== undefined ? u.baseLevel : 0;
   const level = Math.round((cur - baseLevel) / u.step);
+  if (typeof u.price === 'function') return Math.round(u.price(level));
   return Math.round(u.base * Math.pow(u.scale, level));
 }
 
@@ -112,5 +116,6 @@ export function buy(u) {
   if (next > u.max) { say('Maxed'); return; }
   player.cash -= cost;
   player[u.key] = next;
+  if (u.key === 'staminaMax') player.stamina = next;
   say(`${u.name} -> ${next}`);
 }

--- a/js/ui.js
+++ b/js/ui.js
@@ -58,7 +58,7 @@ export function openInventory(player, MATERIALS) {
 }
 
 export function renderShop(player, upgrades, priceFor, buy) {
-  const items = [upgrades.pickaxe, upgrades.boots, upgrades.backpack];
+  const items = [upgrades.pickaxe, upgrades.boots, upgrades.backpack, upgrades.lungs, upgrades.drill];
   shopBody.innerHTML = items.map(u => {
     const cur = player[u.key];
     const nxt = Math.min(u.max, +(cur + u.step).toFixed(2));


### PR DESCRIPTION
## Summary
- Slow default player movement speed
- Add lung expansion pills and drill expander upgrades with custom pricing
- Support drilling multiple blocks and show drill level in stats

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6895fcc2f38083308b46a9e2e7fef29f