### PR TITLE
Add stamina bar, slow player, and reset surface on teleport

### DIFF
--- a/index.html
+++ b/index.html
@@ -19,6 +19,9 @@
     <button id="loadBtn" class="panel">Load</button>
     <input id="loadInput" type="file" accept=".txt" class="hidden" />
   </div>
+  <div id="staminaBar" class="fixed left-2 top-1/2 -translate-y-1/2 w-4 h-48 bg-slate-800 border border-slate-600 overflow-hidden pointer-events-none">
+    <div id="staminaFill" class="absolute bottom-0 left-0 w-full bg-green-500"></div>
+  </div>
   <canvas id="game" width="1280" height="720"></canvas>
   <div id="toasts" class="fixed top-4 right-4 z-30 space-y-2 pointer-events-none"></div>
 

--- a/js/main.js
+++ b/js/main.js
@@ -1,7 +1,7 @@
 import {TILE, MAP_W, MAP_H, MOVE_ACC, MAX_HSPEED, GRAV, FRICTION} from './config.js';
 import {MATERIALS} from './materials.js';
 import {world, worldToTile, isSolidAt} from './world.js';
-import {canvas, ctx, statsEl, say, closeAllModals, isUIOpen, openInventory, openShop, openMarket, renderMarket, marketModal, saveBtn, loadBtn, loadInput} from './ui.js';
+import {canvas, ctx, statsEl, say, closeAllModals, isUIOpen, openInventory, openShop, openMarket, renderMarket, marketModal, saveBtn, loadBtn, loadInput, staminaFill} from './ui.js';
 import {player, buildings, rectsIntersect, totalWeight, invAdd, teleportHome, upgrades, priceFor, buy, sellItem, sellAll, inventoryValue} from './player.js';
 import {saveGameToFile, loadGameFromString} from './save.js';
 
@@ -126,6 +126,7 @@ function draw() {
   ctx.fillRect(player.x - camera.x, player.y - camera.y, player.w, player.h);
 
   statsEl.innerHTML = `Cash: $${player.cash} | Stamina: ${Math.floor(player.stamina)}/${player.staminaMax} | Weight: ${totalWeight()}/${player.carryCap} | Pick: ${player.pickPower} | Drill: ${player.drill} | Speed×${player.speed.toFixed(2)}`;
+  staminaFill.style.height = (player.stamina / player.staminaMax * 100) + '%';
 }
 
 function loop() { tick(); draw(); requestAnimationFrame(loop); }

--- a/js/player.js
+++ b/js/player.js
@@ -1,4 +1,4 @@
-import {TILE} from './config.js';
+import {TILE, MAP_W} from './config.js';
 import {MATERIALS} from './materials.js';
 import {world} from './world.js';
 import {say} from './ui.js';
@@ -18,7 +18,7 @@ export const player = {
   staminaMax: 100,
   carryCap: 40,
   pickPower: 2,
-  speed: 0.6,
+  speed: 0.3,
   drill: 1,
   inventory: []
 };
@@ -82,6 +82,9 @@ export function teleportHome() {
     invTrimTo(player.carryCap);
     say('Overweight. Excess destroyed.');
   }
+  for (let x = 0; x < MAP_W; x++) {
+    world.set(x, 5, 1);
+  }
   const tx = Math.floor(SPAWN_X / TILE);
   world.set(tx, 5, 1);
   world.set(tx, 6, 2);
@@ -95,7 +98,7 @@ export function teleportHome() {
 
 export const upgrades = {
   pickaxe:  { key: 'pickPower', name: 'Pickaxe',           desc: 'Mine harder materials', step: 1,    max: 10,  base: 50,  scale: 1.6,  baseLevel: 0 },
-  boots:    { key: 'speed',     name: 'Boots',             desc: 'Move faster',          step: 0.10, max: 2.0, base: 80,  scale: 1.5,  baseLevel: 0.6 },
+  boots:    { key: 'speed',     name: 'Boots',             desc: 'Move faster',          step: 0.10, max: 2.0, base: 80,  scale: 1.5,  baseLevel: 0.3 },
   backpack: { key: 'carryCap',  name: 'Leather Backpack',  desc: 'Increase carry cap',   step: 20,   max: 300, base: 60,  scale: 1.45, baseLevel: 0 },
   lungs:    { key: 'staminaMax', name: 'Lung Expansion Pills', desc: 'Increase stamina',   step: 20,   max: Infinity, baseLevel: 100, price: level => 150 * Math.pow(level + 1, 1.3) },
   drill:    { key: 'drill',     name: 'Drill Expander',    desc: 'Mine more blocks',     step: 1,    max: 5,      baseLevel: 1,    price: level => (level + 1) * 500 }

--- a/js/ui.js
+++ b/js/ui.js
@@ -2,6 +2,7 @@ export const canvas = document.getElementById('game');
 export const ctx = canvas.getContext('2d');
 export const statsEl = document.getElementById('stats');
 const toastWrap = document.getElementById('toasts');
+export const staminaFill = document.getElementById('staminaFill');
 export const shopModal = document.getElementById('shopModal');
 const shopBody = document.getElementById('shopBody');
 export const invModal = document.getElementById('invModal');


### PR DESCRIPTION
## Summary
- Halve the player's base speed and adjust boots upgrade baseline
- Regrow the entire surface layer when teleporting home
- Add a vertical stamina bar UI showing current stamina

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6895ffaf93248330ac8009b761bd563a