### PR TITLE
Fix selling zero-value items and make mining stamina cost constant

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -29,19 +29,22 @@ function tryMine() {
   else if (lastDir === 'left') dx = -1; else if (lastDir === 'right') dx = 1;
   const cx = player.x + player.w / 2, cy = player.y + player.h / 2;
   const { tx, ty } = worldToTile(cx, cy);
+  const cost = 3;
+  if (player.stamina < cost) return;
   let mined = false;
   for (let i = 1; i <= player.drill; i++) {
     const id = world.get(tx + dx * i, ty + dy * i);
     if (id <= 0) continue;
     const m = MATERIALS[id];
-    const cost = 3 + m.hard;
-    if (m.hard > player.pickPower || player.stamina < cost) break;
+    if (m.hard > player.pickPower) break;
     world.set(tx + dx * i, ty + dy * i, 0);
-    player.stamina -= cost;
     invAdd(id, 1);
     mined = true;
   }
-  if (mined && dy === 1) player.vy = Math.max(player.vy, 0.5);
+  if (mined) {
+    player.stamina -= cost;
+    if (dy === 1) player.vy = Math.max(player.vy, 0.5);
+  }
 }
 
 function resolveCollisions() {

--- a/js/player.js
+++ b/js/player.js
@@ -70,8 +70,8 @@ export function sellItem(id) {
 }
 
 export function sellAll() {
+  if (player.inventory.length === 0) { say('Inventory empty.'); return; }
   const gained = inventoryValue();
-  if (gained === 0) { say('Inventory empty.'); return; }
   player.cash += gained;
   player.inventory = [];
   say(`Sold for $${gained}`);


### PR DESCRIPTION
## Summary
- allow `Sell All` to clear zero-value items like dirt
- charge stamina once per mining action regardless of drill size or block hardness

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689601e3f99883308e38cb29e6c3b6b0