### PR TITLE
Fix and enhance stamina bar behavior

### DIFF
--- a/index.html
+++ b/index.html
@@ -19,7 +19,7 @@
     <button id="loadBtn" class="panel">Load</button>
     <input id="loadInput" type="file" accept=".txt" class="hidden" />
   </div>
-  <div id="staminaBar" class="fixed left-2 top-1/2 -translate-y-1/2 w-4 h-48 bg-slate-800 border border-slate-600 overflow-hidden pointer-events-none">
+  <div id="staminaBar" class="fixed left-2 top-1/2 -translate-y-1/2 w-8 h-48 bg-slate-800 border border-slate-600 overflow-hidden pointer-events-none">
     <div id="staminaFill" class="absolute bottom-0 left-0 w-full bg-green-500"></div>
   </div>
   <canvas id="game" width="1280" height="720"></canvas>

--- a/js/main.js
+++ b/js/main.js
@@ -126,7 +126,9 @@ function draw() {
   ctx.fillRect(player.x - camera.x, player.y - camera.y, player.w, player.h);
 
   statsEl.innerHTML = `Cash: $${player.cash} | Stamina: ${Math.floor(player.stamina)}/${player.staminaMax} | Weight: ${totalWeight()}/${player.carryCap} | Pick: ${player.pickPower} | Drill: ${player.drill} | Speed×${player.speed.toFixed(2)}`;
-  staminaFill.style.height = (player.stamina / player.staminaMax * 100) + '%';
+  const staminaRatio = Math.max(0, Math.min(player.stamina / player.staminaMax, 1));
+  staminaFill.style.height = (staminaRatio * 100) + '%';
+  staminaFill.style.backgroundColor = `hsl(${staminaRatio * 120}, 100%, 50%)`;
 }
 
 function loop() { tick(); draw(); requestAnimationFrame(loop); }


### PR DESCRIPTION
## Summary
- Ensure stamina bar reflects current stamina and color shifts from green to red as it depletes
- Widen stamina bar for better visibility

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689602e50acc833090ead4048dcdda02