### PR TITLE
feat: add weight capacity bar and warning

### DIFF
--- a/index.html
+++ b/index.html
@@ -19,8 +19,13 @@
     <button id="loadBtn" class="panel">Load</button>
     <input id="loadInput" type="file" accept=".txt" class="hidden" />
   </div>
-  <div id="staminaBar" class="fixed left-2 top-1/2 -translate-y-1/2 w-8 h-48 bg-slate-800 border border-slate-600 overflow-hidden pointer-events-none">
-    <div id="staminaFill" class="absolute bottom-0 left-0 w-full bg-green-500"></div>
+  <div class="fixed left-2 top-1/2 -translate-y-1/2 flex gap-2 pointer-events-none">
+    <div id="staminaBar" class="relative w-8 h-48 bg-slate-800 border border-slate-600 overflow-hidden">
+      <div id="staminaFill" class="absolute bottom-0 left-0 w-full bg-green-500"></div>
+    </div>
+    <div id="weightBar" class="relative w-8 h-48 bg-slate-800 border border-slate-600 overflow-hidden">
+      <div id="weightFill" class="absolute bottom-0 left-0 w-full bg-green-500"></div>
+    </div>
   </div>
   <canvas id="game" width="1280" height="720"></canvas>
   <div id="toasts" class="fixed top-4 right-4 z-30 space-y-2 pointer-events-none"></div>

--- a/js/main.js
+++ b/js/main.js
@@ -1,13 +1,14 @@
 import {TILE, MAP_W, MAP_H, MOVE_ACC, MAX_HSPEED, GRAV, FRICTION} from './config.js';
 import {MATERIALS} from './materials.js';
 import {world, worldToTile, isSolidAt} from './world.js';
-import {canvas, ctx, statsEl, say, closeAllModals, isUIOpen, openInventory, openShop, openMarket, renderMarket, marketModal, saveBtn, loadBtn, loadInput, staminaFill} from './ui.js';
+import {canvas, ctx, statsEl, say, closeAllModals, isUIOpen, openInventory, openShop, openMarket, renderMarket, marketModal, saveBtn, loadBtn, loadInput, staminaFill, weightFill} from './ui.js';
 import {player, buildings, rectsIntersect, totalWeight, invAdd, teleportHome, upgrades, priceFor, buy, sellItem, sellAll, inventoryValue} from './player.js';
 import {saveGameToFile, loadGameFromString} from './save.js';
 
 const keys = new Set();
 let mouse = { down: false };
 let lastDir = 'right';
+let weightWarned = false;
 
 addEventListener('keydown', e => {
   const k = e.key;
@@ -132,6 +133,19 @@ function draw() {
   const staminaRatio = Math.max(0, Math.min(player.stamina / player.staminaMax, 1));
   staminaFill.style.height = (staminaRatio * 100) + '%';
   staminaFill.style.backgroundColor = `hsl(${staminaRatio * 120}, 100%, 50%)`;
+
+  const weight = totalWeight();
+  const weightRatio = Math.max(0, Math.min(weight / player.carryCap, 1));
+  weightFill.style.height = (weightRatio * 100) + '%';
+  weightFill.style.backgroundColor = `hsl(${(1 - weightRatio) * 120}, 100%, 50%)`;
+  if (weightRatio >= 0.8) {
+    if (!weightWarned) {
+      say('Inventory almost full! Return to surface soon or excess will be destroyed.');
+      weightWarned = true;
+    }
+  } else {
+    weightWarned = false;
+  }
 }
 
 function loop() { tick(); draw(); requestAnimationFrame(loop); }

--- a/js/ui.js
+++ b/js/ui.js
@@ -3,6 +3,7 @@ export const ctx = canvas.getContext('2d');
 export const statsEl = document.getElementById('stats');
 const toastWrap = document.getElementById('toasts');
 export const staminaFill = document.getElementById('staminaFill');
+export const weightFill = document.getElementById('weightFill');
 export const shopModal = document.getElementById('shopModal');
 const shopBody = document.getElementById('shopBody');
 export const invModal = document.getElementById('invModal');


### PR DESCRIPTION
## Summary
- Add weight capacity progress bar beside stamina bar
- Color bar from green to red and warn when inventory hits 80% capacity

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689605a66f388330965e673ed9a22f00