### PR TITLE
Limit mining to single spacebar presses

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -15,6 +15,7 @@ let weightWarned = false;
 addEventListener('keydown', e => {
   const k = e.key;
   if (k === 'Escape') { closeAllModals(); return; }
+  if (k === ' ' && e.repeat && !player.holdToMine) return;
   const lk = k.toLowerCase();
   keys.add(lk);
   if (lk === 'a') lastDir = 'left';
@@ -98,7 +99,10 @@ function tick() {
   if (!isUIOpen()) {
     if (keys.has('a')) { player.vx -= MOVE_ACC * player.speed; player.facing = -1; }
     if (keys.has('d')) { player.vx += MOVE_ACC * player.speed; player.facing = 1; }
-    if (keys.has(' ')) { tryMine(); keys.delete(' '); }
+    if (keys.has(' ')) {
+      tryMine();
+      if (!player.holdToMine) keys.delete(' ');
+    }
     if (keys.has('e')) { openInventory(player, MATERIALS); keys.delete('e'); }
     if (keys.has('r')) { teleportHome(); keys.delete('r'); }
   }

--- a/js/player.js
+++ b/js/player.js
@@ -22,7 +22,8 @@ const BASE_PLAYER = {
   drill: 1,
   inventory: [],
   ascensions: 0,
-  ascensionUnlocked: false
+  ascensionUnlocked: false,
+  holdToMine: false
 };
 
 export const player = { ...BASE_PLAYER };
@@ -105,8 +106,8 @@ export function teleportHome() {
 }
 
 function resetPlayerStats() {
-  const { ascensions, ascensionUnlocked } = player;
-  Object.assign(player, { ...BASE_PLAYER, ascensions, ascensionUnlocked });
+  const { ascensions, ascensionUnlocked, holdToMine } = player;
+  Object.assign(player, { ...BASE_PLAYER, ascensions, ascensionUnlocked, holdToMine });
   player.inventory = [];
 }
 


### PR DESCRIPTION
## Summary
- Prevent holding space to mine repeatedly by ignoring repeated keydown events
- Keep space key active when hold-to-mine upgrade is unlocked
- Preserve future hold-to-mine upgrade across ascensions

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689612c46d5c8330bd0c349089f348db