### PR TITLE
feat: add auto saving

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,8 @@ npm run dev
 
 Open the printed URL to play the game during development.
 
+The game automatically saves progress to your browser's local storage and will attempt to load it on startup.
+
 ## Building
 
 ```bash

--- a/js/main.js
+++ b/js/main.js
@@ -3,9 +3,12 @@ import {MATERIALS} from './materials.js';
 import {world, worldToTile, isSolidAt, generateWorld} from './world.js';
 import {canvas, ctx, statsEl, say, closeAllModals, isUIOpen, openInventory, openShop, openMarket, renderMarket, marketModal, saveBtn, loadBtn, loadInput, staminaFill, weightFill, openModal, ascendModal, ascendBtn} from './ui.js';
 import {player, buildings, rectsIntersect, totalWeight, invAdd, teleportHome, upgrades, priceFor, buy, sellItem, sellAll, inventoryValue, ASCENSION_BUILDING, ascend} from './player.js';
-import {saveGameToFile, loadGameFromString} from './save.js';
+import {saveGameToFile, loadGameFromString, saveGameToStorage, loadGameFromStorage} from './save.js';
 
 generateWorld(player.ascensions);
+if (loadGameFromStorage()) {
+  say('Game loaded');
+}
 
 const keys = new Set();
 let mouse = { down: false };
@@ -187,3 +190,7 @@ loadInput.onchange = e => {
 };
 
 ascendBtn.onclick = () => { if (ascend()) closeAllModals(); };
+
+saveGameToStorage();
+setInterval(saveGameToStorage, 10000);
+addEventListener('beforeunload', saveGameToStorage);

--- a/js/save.js
+++ b/js/save.js
@@ -42,3 +42,19 @@ export function loadGameFromString(b64) {
     return false;
   }
 }
+
+const SAVE_KEY = 'raksmine-save';
+
+export function saveGameToStorage() {
+  try {
+    localStorage.setItem(SAVE_KEY, serializeGame());
+  } catch (e) {
+    console.error('Failed to save game', e);
+  }
+}
+
+export function loadGameFromStorage() {
+  const data = localStorage.getItem(SAVE_KEY);
+  if (!data) return false;
+  return loadGameFromString(data);
+}


### PR DESCRIPTION
## Summary
- persist game state using browser storage
- auto-load existing save state on startup
- periodically save progress and save on page unload

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6896149fb9288330a0b560d9f4d6b389