### PR TITLE
Update ore colors

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -160,7 +160,7 @@ function draw() {
     ctx.fillRect(tx * TILE - camera.x, ty * TILE - camera.y, TILE, TILE);
   }
   for (const b of buildings) {
-    ctx.fillStyle = b.kind === 'shop' ? '#2563eb' : b.kind === 'market' ? '#9333ea' : '#16a34a';
+    ctx.fillStyle = b.kind === 'shop' ? '#2563eb' : b.kind === 'market' ? '#9333ea' : '#1fa94c';
     ctx.fillRect(b.x - camera.x, b.y - camera.y, b.w, b.h);
     ctx.fillStyle = '#e5e7eb'; ctx.font = '12px system-ui';
     ctx.fillText(b.name, b.x - camera.x + 2, b.y - camera.y - 4);

--- a/js/materials.js
+++ b/js/materials.js
@@ -1,13 +1,13 @@
 export const MATERIALS = [
   {id:0, name:'Air',     color:null,      solid:false, hard:0, value:0,  weight:0},
-  {id:1, name:'Grass',   color:'#16a34a', solid:true,  hard:1, value:0,  weight:1},
-  {id:2, name:'Dirt',    color:'#4d3b2f', solid:true,  hard:1, value:0,  weight:1},
+  {id:1, name:'Grass',   color:'#1fa94c', solid:true,  hard:1, value:0,  weight:1},
+  {id:2, name:'Dirt',    color:'#7b5134', solid:true,  hard:1, value:0,  weight:1},
   // Stone and ores
-  {id:3, name:'Stone',   color:'#6b7280', solid:true,  hard:2, value:1,  weight:2, rarity:80, minDepth:22},
-  {id:4, name:'Copper',  color:'#b87333', solid:true,  hard:3, value:5,  weight:3, rarity:20, minDepth:30},
-  {id:5, name:'Iron',    color:'#a3a3a3', solid:true,  hard:4, value:10, weight:4, rarity:10, minDepth:60},
-  {id:6, name:'Gold',    color:'#eab308', solid:true,  hard:6, value:30, weight:6, rarity:5,  minDepth:120},
-  {id:7, name:'Tin',     color:'#9ea7a6', solid:true,  hard:3, value:8,  weight:3, rarity:15, minDepth:40,  ascension:1},
-  {id:8, name:'Diamond', color:'#38bdf8', solid:true,  hard:9, value:100,weight:1, rarity:1,  minDepth:300, ascension:1}
+  {id:3, name:'Stone',   color:'#808a99', solid:true,  hard:2, value:1,  weight:2, rarity:80, minDepth:22},
+  {id:4, name:'Copper',  color:'#c67c29', solid:true,  hard:3, value:5,  weight:3, rarity:20, minDepth:30},
+  {id:5, name:'Iron',    color:'#8d8d92', solid:true,  hard:4, value:10, weight:4, rarity:10, minDepth:60},
+  {id:6, name:'Gold',    color:'#ffcc33', solid:true,  hard:6, value:30, weight:6, rarity:5,  minDepth:120},
+  {id:7, name:'Tin',     color:'#c4d5d5', solid:true,  hard:3, value:8,  weight:3, rarity:15, minDepth:40,  ascension:1},
+  {id:8, name:'Diamond', color:'#00d0ff', solid:true,  hard:9, value:100,weight:1, rarity:1,  minDepth:300, ascension:1}
 ];
 


### PR DESCRIPTION
## Summary
- refresh ore and material colours for better visual contrast
- sync default grass colour used for buildings

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68962da0fdf483309f1a14f2c8c4efe3