### PR TITLE
Add notification position controls and bar fade near edge

### DIFF
--- a/index.html
+++ b/index.html
@@ -29,7 +29,7 @@
     </div>
   </div>
   <canvas id="game" width="1280" height="720"></canvas>
-  <div id="toasts" class="fixed top-4 right-4 z-30 space-y-2 pointer-events-none"></div>
+  <div id="toasts" class="fixed z-30 space-y-2 pointer-events-none"></div>
 
   <!-- Shop modal -->
   <div id="shopModal" class="hidden fixed inset-0 z-20 flex items-center justify-center bg-black/50">
@@ -95,6 +95,14 @@
         <div>
           <label for="autosaveRange" class="font-medium">Autosave Interval: <span id="autosaveLabel"></span></label>
           <input id="autosaveRange" type="range" min="10" max="300" step="10" class="w-full">
+        </div>
+        <div>
+          <label for="toastXInput" class="font-medium">Notification X Position</label>
+          <input id="toastXInput" type="number" class="w-full">
+        </div>
+        <div>
+          <label for="toastYInput" class="font-medium">Notification Y Position</label>
+          <input id="toastYInput" type="number" class="w-full">
         </div>
         <div>
           <h4 class="font-medium mb-1">Key Bindings</h4>

--- a/js/main.js
+++ b/js/main.js
@@ -1,7 +1,7 @@
 import {TILE, MAP_W, MAP_H, MOVE_ACC, MAX_HSPEED, GRAV, FRICTION} from './config.js';
 import {MATERIALS} from './materials.js';
 import {world, worldToTile, isSolidAt, generateWorld} from './world.js';
-import {canvas, ctx, statsEl, say, closeAllModals, closeModal, isUIOpen, openInventory, openShop, openMarket, marketModal, saveBtn, loadBtn, loadInput, staminaFill, weightFill, openModal, ascendModal, ascendBtn, settingsBtn, settingsModal, autosaveRange, autosaveLabel, keybindsTable, hardResetBtn} from './ui.js';
+import {canvas, ctx, statsEl, say, closeAllModals, closeModal, isUIOpen, openInventory, openShop, openMarket, marketModal, saveBtn, loadBtn, loadInput, staminaBar, staminaFill, weightBar, weightFill, openModal, ascendModal, ascendBtn, settingsBtn, settingsModal, autosaveRange, autosaveLabel, toastXInput, toastYInput, keybindsTable, hardResetBtn, toastWrap} from './ui.js';
 import {player, buildings, rectsIntersect, totalWeight, invAdd, teleportHome, upgrades, priceFor, buy, sellItem, sellAll, inventoryValue, ASCENSION_BUILDING, ascend} from './player.js';
 import {saveGameToFile, loadGameFromString, saveGameToStorage, loadGameFromStorage, SAVE_KEY} from './save.js';
 
@@ -187,6 +187,11 @@ function draw() {
   } else {
     weightWarned = false;
   }
+
+  const playerCol = Math.floor((player.x + player.w / 2) / TILE);
+  const faded = playerCol < 5;
+  staminaBar.style.opacity = faded ? '0.5' : '1';
+  weightBar.style.opacity = faded ? '0.5' : '1';
 }
 
 function loop() { tick(); draw(); requestAnimationFrame(loop); }
@@ -250,6 +255,26 @@ autosaveRange.oninput = () => {
   refreshAutosaveLabel();
   clearInterval(autosaveHandle);
   autosaveHandle = setInterval(saveGameToStorage, autosaveMs);
+};
+
+let toastX = parseInt(localStorage.getItem('toastX') || '16');
+let toastY = parseInt(localStorage.getItem('toastY') || '16');
+function applyToastPos() {
+  toastWrap.style.left = toastX + 'px';
+  toastWrap.style.top = toastY + 'px';
+}
+applyToastPos();
+toastXInput.value = toastX;
+toastYInput.value = toastY;
+toastXInput.oninput = () => {
+  toastX = parseInt(toastXInput.value || '0');
+  localStorage.setItem('toastX', toastX);
+  applyToastPos();
+};
+toastYInput.oninput = () => {
+  toastY = parseInt(toastYInput.value || '0');
+  localStorage.setItem('toastY', toastY);
+  applyToastPos();
 };
 
 hardResetBtn.onclick = () => {

--- a/js/ui.js
+++ b/js/ui.js
@@ -1,8 +1,10 @@
 export const canvas = document.getElementById('game');
 export const ctx = canvas.getContext('2d');
 export const statsEl = document.getElementById('stats');
-const toastWrap = document.getElementById('toasts');
+export const toastWrap = document.getElementById('toasts');
+export const staminaBar = document.getElementById('staminaBar');
 export const staminaFill = document.getElementById('staminaFill');
+export const weightBar = document.getElementById('weightBar');
 export const weightFill = document.getElementById('weightFill');
 export const shopModal = document.getElementById('shopModal');
 const shopBody = document.getElementById('shopBody');
@@ -21,6 +23,8 @@ export const settingsModal = document.getElementById('settingsModal');
 export const settingsClose = document.getElementById('settingsClose');
 export const autosaveRange = document.getElementById('autosaveRange');
 export const autosaveLabel = document.getElementById('autosaveLabel');
+export const toastXInput = document.getElementById('toastXInput');
+export const toastYInput = document.getElementById('toastYInput');
 export const keybindsTable = document.getElementById('keybindsTable');
 export const hardResetBtn = document.getElementById('hardResetBtn');
 


### PR DESCRIPTION
## Summary
- Allow players to set notification start X/Y in settings with persistent storage
- Progress bars fade to 50% opacity when player is within the leftmost five columns

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689630c0229483308910536489431551