### PR TITLE
Add soft reset option and highlight equipped pages

### DIFF
--- a/index.html
+++ b/index.html
@@ -78,12 +78,14 @@
         <h3 class="text-base font-semibold">Ascension</h3>
         <button id="ascendClose" class="px-2 py-1 text-sm rounded-md border border-slate-700 hover:bg-slate-800">Close</button>
       </div>
-      <div class="p-4 space-y-3 text-sm">
-        <p>Reset the world for new opportunities. Cost: $10,000.</p>
-        <button id="ascendBtn" class="px-3 py-1.5 rounded-md border border-slate-600 w-full">Ascend</button>
+        <div class="p-4 space-y-3 text-sm">
+          <p>Reset the world for new opportunities. Cost: $10,000.</p>
+          <button id="ascendBtn" class="px-3 py-1.5 rounded-md border border-slate-600 w-full">Ascend</button>
+          <p class="pt-2">Soft reset will regenerate the world and reset upgrades without affecting ascension progress.</p>
+          <button id="softResetBtn" class="px-3 py-1.5 rounded-md border border-slate-600 w-full">Soft Reset</button>
+        </div>
       </div>
     </div>
-  </div>
 
   <!-- Pages modal -->
   <div id="pagesModal" class="hidden fixed inset-0 z-20 flex items-center justify-center bg-black/50">

--- a/js/main.js
+++ b/js/main.js
@@ -1,8 +1,8 @@
 import {TILE, MAP_W, MAP_H, MOVE_ACC, MAX_HSPEED, GRAV, FRICTION} from './config.js';
 import {MATERIALS} from './materials.js';
 import {world, worldToTile, isSolidAt, generateWorld} from './world.js';
-import {canvas, ctx, statsEl, say, closeAllModals, closeModal, isUIOpen, openInventory, openShop, openMarket, marketModal, saveBtn, loadBtn, loadInput, staminaBar, staminaFill, weightBar, weightFill, openModal, ascendModal, ascendBtn, settingsBtn, settingsModal, autosaveRange, autosaveLabel, toastXInput, toastYInput, keybindsTable, hardResetBtn, toastWrap} from './ui.js';
-import {player, buildings, rectsIntersect, totalWeight, invAdd, teleportHome, upgrades, priceFor, buy, sellItem, sellAll, inventoryValue, ASCENSION_BUILDING, ascend} from './player.js';
+import {canvas, ctx, statsEl, say, closeAllModals, closeModal, isUIOpen, openInventory, openShop, openMarket, marketModal, saveBtn, loadBtn, loadInput, staminaBar, staminaFill, weightBar, weightFill, openModal, ascendModal, ascendBtn, softResetBtn, settingsBtn, settingsModal, autosaveRange, autosaveLabel, toastXInput, toastYInput, keybindsTable, hardResetBtn, toastWrap} from './ui.js';
+import {player, buildings, rectsIntersect, totalWeight, invAdd, teleportHome, upgrades, priceFor, buy, sellItem, sellAll, inventoryValue, ASCENSION_BUILDING, ascend, softReset} from './player.js';
 import {setupPages} from './pages.js';
 import {saveGameToFile, loadGameFromString, saveGameToStorage, loadGameFromStorage, SAVE_KEY} from './save.js';
 
@@ -234,6 +234,7 @@ loadInput.onchange = e => {
 };
 
 ascendBtn.onclick = () => { if (ascend()) closeAllModals(); };
+softResetBtn.onclick = () => { if (softReset()) closeAllModals(); };
 
 settingsBtn.onclick = () => { renderKeybinds(); openModal(settingsModal); };
 

--- a/js/pages.js
+++ b/js/pages.js
@@ -111,7 +111,8 @@ export function setupPages(player) {
         const highest = owned ? Math.max(...Object.keys(owned).map(Number)) : 0;
         const known = total > 0;
         const merge = canMerge(owned);
-        return `<div data-id='${p.id}' class='pageTile border border-slate-700 rounded-lg p-2 ${known ? 'cursor-pointer' : ''}'>` +
+        const equipped = player.equippedPages[p.id];
+        return `<div data-id='${p.id}' class='pageTile border border-slate-700 rounded-lg p-2 ${known ? 'cursor-pointer' : ''} ${equipped ? 'bg-slate-700' : ''}'>` +
           `<div class='font-medium'>${known ? p.name : 'Unknown'}</div>` +
           `<div class='text-xs text-slate-400'>${p.rarity}</div>` +
           `<div class='text-xs'>Lv ${highest}</div>` +

--- a/js/player.js
+++ b/js/player.js
@@ -133,6 +133,20 @@ export function ascend() {
   return true;
 }
 
+export function softReset() {
+  resetPlayerStats();
+  generateWorld(player.ascensions, player.equippedPages);
+  buildings.length = 0;
+  buildings.push(...BASE_BUILDINGS);
+  if (player.ascensionUnlocked || player.ascensions > 0) {
+    player.ascensionUnlocked = true;
+    buildings.push({ ...ASCENSION_BUILDING });
+  }
+  teleportHome();
+  say('The world has been refreshed.');
+  return true;
+}
+
 export const upgrades = {
   pickaxe:  { key: 'pickPower', name: 'Pickaxe',           desc: 'Mine harder materials', step: 1,    max: 10,  base: 50,  scale: 1.6,  baseLevel: 0 },
   boots:    { key: 'speed',     name: 'Boots',             desc: 'Move faster',          step: 0.10, max: 2.0, base: 80,  scale: 1.5,  baseLevel: 0.3 },

--- a/js/ui.js
+++ b/js/ui.js
@@ -18,6 +18,7 @@ export const loadBtn = document.getElementById('loadBtn');
 export const loadInput = document.getElementById('loadInput');
 export const ascendModal = document.getElementById('ascendModal');
 export const ascendBtn = document.getElementById('ascendBtn');
+export const softResetBtn = document.getElementById('softResetBtn');
 export const settingsBtn = document.getElementById('settingsBtn');
 export const settingsModal = document.getElementById('settingsModal');
 export const settingsClose = document.getElementById('settingsClose');


### PR DESCRIPTION
## Summary
- Add soft reset button to ascension modal to regenerate world without affecting ascension progress
- Reset player stats and world on soft reset while preserving ascension data
- Highlight equipped pages in Pages UI with a background color

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6896456a8ba08330a3266ffb98dcc380