### PR TITLE
feat: generate ore pages dynamically

### DIFF
--- a/js/materials.js
+++ b/js/materials.js
@@ -4,10 +4,10 @@ export const MATERIALS = [
   {id:2, name:'Dirt',    color:'#7b5134', solid:true,  hard:1, value:0,  weight:1},
   // Stone and ores
   {id:3, name:'Stone',   color:'#808a99', solid:true,  hard:2, value:1,  weight:2, rarity:80, minDepth:22},
-  {id:4, name:'Copper',  color:'#c67c29', solid:true,  hard:3, value:5,  weight:3, rarity:20, minDepth:30},
-  {id:5, name:'Iron',    color:'#8d8d92', solid:true,  hard:4, value:10, weight:4, rarity:10, minDepth:60},
-  {id:6, name:'Gold',    color:'#ffcc33', solid:true,  hard:6, value:30, weight:6, rarity:5,  minDepth:120},
-  {id:7, name:'Tin',     color:'#c4d5d5', solid:true,  hard:3, value:8,  weight:3, rarity:15, minDepth:40,  ascension:1},
-  {id:8, name:'Diamond', color:'#00d0ff', solid:true,  hard:9, value:100,weight:1, rarity:1,  minDepth:300, ascension:1}
+  {id:4, name:'Copper',  color:'#c67c29', solid:true,  hard:3, value:5,  weight:3, rarity:20, minDepth:30,  ore:true},
+  {id:5, name:'Iron',    color:'#8d8d92', solid:true,  hard:4, value:10, weight:4, rarity:10, minDepth:60,  ore:true},
+  {id:6, name:'Gold',    color:'#ffcc33', solid:true,  hard:6, value:30, weight:6, rarity:5,  minDepth:120, ore:true},
+  {id:7, name:'Tin',     color:'#c4d5d5', solid:true,  hard:3, value:8,  weight:3, rarity:15, minDepth:40,  ascension:1, ore:true},
+  {id:8, name:'Diamond', color:'#00d0ff', solid:true,  hard:9, value:100,weight:1, rarity:1,  minDepth:300, ascension:1, ore:true}
 ];
 

--- a/js/pages.js
+++ b/js/pages.js
@@ -1,42 +1,47 @@
 import { openModal, closeModal, say } from './ui.js';
+import { MATERIALS } from './materials.js';
 
 export const MERGE_COST = 5;
 
-export const PAGES = [
-  {
-    id: 'iron_spawn',
-    name: 'Iron Lore',
-    rarity: 'Common',
-    weight: 60,
-    desc: 'Increase iron spawn rate by 10% per level.',
-    apply: (mats, lvl) => {
-      const iron = mats.find(m => m.id === 5);
-      if (iron) iron.rarity = Math.round(iron.rarity * (1 + 0.1 * lvl));
-    }
-  },
-  {
-    id: 'iron_depth',
-    name: 'Iron Mapping',
-    rarity: 'Uncommon',
-    weight: 30,
-    desc: 'Reduce iron minimum depth by 5 per level.',
-    apply: (mats, lvl) => {
-      const iron = mats.find(m => m.id === 5);
-      if (iron) iron.minDepth = Math.max(0, (iron.minDepth || 0) - 5 * lvl);
-    }
-  },
-  {
-    id: 'gold_spawn',
-    name: 'Gold Scriptures',
-    rarity: 'Rare',
-    weight: 10,
-    desc: 'Increase gold spawn rate by 10% per level.',
-    apply: (mats, lvl) => {
-      const gold = mats.find(m => m.id === 6);
-      if (gold) gold.rarity = Math.round(gold.rarity * (1 + 0.1 * lvl));
-    }
+function rarityInfo(value) {
+  if (value >= 15) return { rarity: 'Common', weight: 60 };
+  if (value >= 8) return { rarity: 'Uncommon', weight: 30 };
+  return { rarity: 'Rare', weight: 10 };
+}
+
+function generateOrePages() {
+  const pages = [];
+  const ores = MATERIALS.filter(m => m.ore);
+  for (const ore of ores) {
+    const slug = ore.name.toLowerCase().replace(/\s+/g, '_');
+    const info = rarityInfo(ore.rarity || 0);
+    pages.push({
+      id: `${slug}_spawn`,
+      name: `${ore.name} Lore`,
+      rarity: info.rarity,
+      weight: info.weight,
+      desc: `Increase ${ore.name.toLowerCase()} spawn rate by 10% per level.`,
+      apply: (mats, lvl) => {
+        const mat = mats.find(m => m.id === ore.id);
+        if (mat) mat.rarity = Math.round(mat.rarity * (1 + 0.1 * lvl));
+      }
+    });
+    pages.push({
+      id: `${slug}_depth`,
+      name: `${ore.name} Mapping`,
+      rarity: info.rarity,
+      weight: info.weight,
+      desc: `Reduce ${ore.name.toLowerCase()} minimum depth by 5 per level.`,
+      apply: (mats, lvl) => {
+        const mat = mats.find(m => m.id === ore.id);
+        if (mat) mat.minDepth = Math.max(0, (mat.minDepth || 0) - 5 * lvl);
+      }
+    });
   }
-];
+  return pages;
+}
+
+export const PAGES = generateOrePages();
 
 const PAGE_MAP = Object.fromEntries(PAGES.map(p => [p.id, p]));
 


### PR DESCRIPTION
## Summary
- generate spawn/depth page definitions for every ore
- mark ores in material data for automatic page generation

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6896481bd9c4833099c688dbd539b092