### PR TITLE
Add ascension shop with upgrade tree

### DIFF
--- a/index.html
+++ b/index.html
@@ -81,11 +81,23 @@
         <div class="p-4 space-y-3 text-sm">
           <p>Reset the world for new opportunities. Cost: $10,000.</p>
           <button id="ascendBtn" class="px-3 py-1.5 rounded-md border border-slate-600 w-full">Ascend</button>
+          <button id="ascShopBtn" class="px-3 py-1.5 rounded-md border border-slate-600 w-full">Ascension Shop</button>
           <p class="pt-2">Soft reset will regenerate the world and reset upgrades without affecting ascension progress.</p>
           <button id="softResetBtn" class="px-3 py-1.5 rounded-md border border-slate-600 w-full">Soft Reset</button>
         </div>
       </div>
     </div>
+
+  <!-- Ascension shop modal -->
+  <div id="ascShopModal" class="hidden fixed inset-0 z-20 flex items-center justify-center bg-black/50">
+    <div class="bg-slate-900 border border-slate-700 rounded-2xl shadow-xl w-[500px] max-w-[92vw]">
+      <div class="flex items-center justify-between px-4 py-3 border-b border-slate-700">
+        <h3 class="text-base font-semibold">Ascension Upgrades</h3>
+        <button id="ascShopClose" class="px-2 py-1 text-sm rounded-md border border-slate-700 hover:bg-slate-800">Close</button>
+      </div>
+      <div id="ascShopBody" class="p-4 text-sm"></div>
+    </div>
+  </div>
 
   <!-- Pages modal -->
   <div id="pagesModal" class="hidden fixed inset-0 z-20 flex items-center justify-center bg-black/50">

--- a/js/ascension.js
+++ b/js/ascension.js
@@ -1,0 +1,90 @@
+import { openModal, ascShopBtn, ascShopModal, ascShopBody, say } from './ui.js';
+
+export const ASCENSION_UPGRADES = [
+  {
+    id: 'drill_range',
+    name: '+1 Drill Range',
+    desc: 'Increase drill range by 1.',
+    cost: 1,
+    tier: 0,
+    apply: p => { p.drill += 1; }
+  },
+  {
+    id: 'backpack_size',
+    name: '+100 Backpack Size',
+    desc: 'Increase backpack capacity by 100.',
+    cost: 1,
+    tier: 1,
+    requires: ['drill_range'],
+    apply: p => { p.carryCap += 100; }
+  },
+  {
+    id: 'stamina_gain',
+    name: '2x Stamina Gain',
+    desc: 'Double stamina regeneration.',
+    cost: 2,
+    tier: 1,
+    requires: ['drill_range'],
+    apply: p => { p.staminaRegen = (p.staminaRegen || 1) * 2; }
+  }
+];
+
+const UP_MAP = Object.fromEntries(ASCENSION_UPGRADES.map(u => [u.id, u]));
+
+export function applyAscensionUpgrades(player) {
+  if (!player.ascensionUpgrades) player.ascensionUpgrades = {};
+  for (const id in player.ascensionUpgrades) {
+    const up = UP_MAP[id];
+    if (up && typeof up.apply === 'function') up.apply(player);
+  }
+}
+
+export function setupAscensionShop(player) {
+  if (!ascShopBtn) return;
+
+  function owned(id) { return player.ascensionUpgrades && player.ascensionUpgrades[id]; }
+
+  function canBuy(up) {
+    if (owned(up.id)) return false;
+    if (player.ascensionPoints < up.cost) return false;
+    if (up.requires && !up.requires.every(r => owned(r))) return false;
+    return true;
+  }
+
+  function buy(id) {
+    const up = UP_MAP[id];
+    if (!up || !canBuy(up)) return;
+    player.ascensionPoints -= up.cost;
+    if (!player.ascensionUpgrades) player.ascensionUpgrades = {};
+    player.ascensionUpgrades[id] = true;
+    up.apply(player);
+    say('Purchased ' + up.name);
+    render();
+  }
+
+  function render() {
+    const tiers = {};
+    for (const up of ASCENSION_UPGRADES) {
+      (tiers[up.tier] ||= []).push(up);
+    }
+    const order = Object.keys(tiers).map(Number).sort((a, b) => a - b);
+    let html = `<div class='mb-3'>Ascension Points: ${player.ascensionPoints}</div><div class='flex gap-4'>`;
+    for (const t of order) {
+      html += "<div class='flex flex-col gap-2'>";
+      for (const up of tiers[t]) {
+        const bought = owned(up.id);
+        const disabled = !canBuy(up) ? 'opacity-50 cursor-not-allowed' : '';
+        html += `<button data-id='${up.id}' class='ascUpg px-2 py-1 rounded-md border border-slate-600 ${disabled} ${bought ? 'bg-slate-700' : ''}'>${up.name}<br><span class='text-xs text-slate-400'>Cost ${up.cost}</span></button>`;
+      }
+      html += '</div>';
+    }
+    html += '</div>';
+    ascShopBody.innerHTML = html;
+    ascShopBody.querySelectorAll('button.ascUpg').forEach(btn => {
+      btn.onclick = () => buy(btn.getAttribute('data-id'));
+    });
+  }
+
+  ascShopBtn.onclick = () => { render(); openModal(ascShopModal); };
+}
+

--- a/js/main.js
+++ b/js/main.js
@@ -4,6 +4,7 @@ import {world, worldToTile, isSolidAt, generateWorld} from './world.js';
 import {canvas, ctx, statsEl, say, closeAllModals, closeModal, isUIOpen, openInventory, openShop, openMarket, marketModal, saveBtn, loadBtn, loadInput, staminaBar, staminaFill, weightBar, weightFill, openModal, ascendModal, ascendBtn, softResetBtn, settingsBtn, settingsModal, autosaveRange, autosaveLabel, toastXInput, toastYInput, keybindsTable, hardResetBtn, toastWrap} from './ui.js';
 import {player, buildings, rectsIntersect, totalWeight, invAdd, teleportHome, upgrades, priceFor, buy, sellItem, sellAll, inventoryValue, ASCENSION_BUILDING, ascend, softReset} from './player.js';
 import {setupPages} from './pages.js';
+import {setupAscensionShop} from './ascension.js';
 import {saveGameToFile, loadGameFromString, saveGameToStorage, loadGameFromStorage, SAVE_KEY} from './save.js';
 
 generateWorld(player.ascensions, player.equippedPages);
@@ -11,6 +12,7 @@ if (loadGameFromStorage()) {
   say('Game loaded');
 }
 setupPages(player);
+setupAscensionShop(player);
 
 const keys = new Set();
 let mouse = { down: false };

--- a/js/player.js
+++ b/js/player.js
@@ -3,6 +3,7 @@ import {MATERIALS} from './materials.js';
 import {world, generateWorld} from './world.js';
 import {say} from './ui.js';
 import {awardRandomPage} from './pages.js';
+import {applyAscensionUpgrades} from './ascension.js';
 
 export const SPAWN_X = TILE * 10;
 
@@ -26,6 +27,9 @@ const BASE_PLAYER = {
   equippedPages: {},
   ascensions: 0,
   ascensionUnlocked: false,
+  ascensionPoints: 0,
+  ascensionUpgrades: {},
+  staminaRegen: 1,
   holdToMine: false
 };
 
@@ -109,14 +113,16 @@ export function teleportHome() {
 }
 
 function resetPlayerStats() {
-  const { ascensions, ascensionUnlocked, holdToMine, pages, equippedPages } = player;
-  Object.assign(player, { ...BASE_PLAYER, ascensions, ascensionUnlocked, holdToMine, pages, equippedPages });
+  const { ascensions, ascensionUnlocked, holdToMine, pages, equippedPages, ascensionPoints, ascensionUpgrades } = player;
+  Object.assign(player, { ...BASE_PLAYER, ascensions, ascensionUnlocked, holdToMine, pages, equippedPages, ascensionPoints, ascensionUpgrades });
   player.inventory = [];
+  applyAscensionUpgrades(player);
 }
 
 export function ascend() {
   if (player.cash < 10000) { say('Need $10000 to ascend.'); return false; }
   player.ascensions++;
+  player.ascensionPoints += player.ascensions;
   player.cash = 0;
   resetPlayerStats();
   generateWorld(player.ascensions, player.equippedPages);
@@ -129,6 +135,7 @@ export function ascend() {
   teleportHome();
   const pg = awardRandomPage(player);
   say('The world has been reborn.');
+  say('Gained ' + player.ascensions + ' ascension points.');
   if (pg) say(`You received a ${pg.rarity} Page: ${pg.name}`);
   return true;
 }

--- a/js/save.js
+++ b/js/save.js
@@ -31,6 +31,8 @@ export function loadGameFromString(b64) {
     player.inventory = state.player.inventory || [];
     player.pages = state.player.pages || {};
     player.equippedPages = state.player.equippedPages || {};
+    player.ascensionUpgrades = state.player.ascensionUpgrades || {};
+    player.ascensionPoints = state.player.ascensionPoints || 0;
     buildings.length = 0;
     if (Array.isArray(state.buildings)) {
       for (const b of state.buildings) buildings.push(b);

--- a/js/ui.js
+++ b/js/ui.js
@@ -18,6 +18,9 @@ export const loadBtn = document.getElementById('loadBtn');
 export const loadInput = document.getElementById('loadInput');
 export const ascendModal = document.getElementById('ascendModal');
 export const ascendBtn = document.getElementById('ascendBtn');
+export const ascShopBtn = document.getElementById('ascShopBtn');
+export const ascShopModal = document.getElementById('ascShopModal');
+export const ascShopBody = document.getElementById('ascShopBody');
 export const softResetBtn = document.getElementById('softResetBtn');
 export const settingsBtn = document.getElementById('settingsBtn');
 export const settingsModal = document.getElementById('settingsModal');
@@ -33,6 +36,7 @@ document.getElementById('shopClose').onclick = () => closeAllModals();
 document.getElementById('invClose').onclick = () => closeAllModals();
 document.getElementById('marketClose').onclick = () => closeAllModals();
 document.getElementById('ascendClose').onclick = () => closeAllModals();
+document.getElementById('ascShopClose').onclick = () => closeAllModals();
 settingsClose.onclick = () => closeAllModals();
 
 export function say(text) {
@@ -49,8 +53,8 @@ export function say(text) {
 
 export function openModal(el) { el.classList.remove('hidden'); el.classList.add('flex'); }
 export function closeModal(el) { el.classList.add('hidden'); el.classList.remove('flex'); }
-export function closeAllModals() { closeModal(shopModal); closeModal(invModal); closeModal(marketModal); closeModal(ascendModal); closeModal(settingsModal); }
-export function isUIOpen() { return !shopModal.classList.contains('hidden') || !invModal.classList.contains('hidden') || !marketModal.classList.contains('hidden') || !ascendModal.classList.contains('hidden') || !settingsModal.classList.contains('hidden'); }
+export function closeAllModals() { closeModal(shopModal); closeModal(invModal); closeModal(marketModal); closeModal(ascendModal); closeModal(ascShopModal); closeModal(settingsModal); }
+export function isUIOpen() { return !shopModal.classList.contains('hidden') || !invModal.classList.contains('hidden') || !marketModal.classList.contains('hidden') || !ascendModal.classList.contains('hidden') || !ascShopModal.classList.contains('hidden') || !settingsModal.classList.contains('hidden'); }
 
 export function renderInventory(player, MATERIALS) {
   const counts = new Map();


### PR DESCRIPTION
## Summary
- Add new Ascension Shop modal accessed from the ascension building
- Introduce modular ascension upgrade tree with drill range, backpack size, and stamina gain upgrades
- Track ascension points and purchased upgrades across resets and saves

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68964acc0fc48330b4b9aeff1c9fbd3a