### PR TITLE
Simplify ascension and soft reset flow

### DIFF
--- a/index.html
+++ b/index.html
@@ -79,11 +79,9 @@
         <button id="ascendClose" class="px-2 py-1 text-sm rounded-md border border-slate-700 hover:bg-slate-800">Close</button>
       </div>
         <div class="p-4 space-y-3 text-sm">
-          <p>Reset the world for new opportunities. Cost: $10,000.</p>
+          <p>Reset the world for new opportunities. Cost: $10,000. If you can't afford it, you may ascend for no gain.</p>
           <button id="ascendBtn" class="px-3 py-1.5 rounded-md border border-slate-600 w-full">Ascend</button>
           <button id="ascShopBtn" class="px-3 py-1.5 rounded-md border border-slate-600 w-full">Ascension Shop</button>
-          <p class="pt-2">Soft reset will regenerate the world and reset upgrades without affecting ascension progress.</p>
-          <button id="softResetBtn" class="px-3 py-1.5 rounded-md border border-slate-600 w-full">Soft Reset</button>
         </div>
       </div>
     </div>

--- a/js/main.js
+++ b/js/main.js
@@ -1,8 +1,8 @@
 import {TILE, MAP_W, MAP_H, MOVE_ACC, MAX_HSPEED, GRAV, FRICTION} from './config.js';
 import {MATERIALS} from './materials.js';
 import {world, worldToTile, isSolidAt, generateWorld} from './world.js';
-import {canvas, ctx, statsEl, say, closeAllModals, closeModal, isUIOpen, openInventory, openShop, openMarket, marketModal, saveBtn, loadBtn, loadInput, staminaBar, staminaFill, weightBar, weightFill, openModal, ascendModal, ascendBtn, softResetBtn, settingsBtn, settingsModal, autosaveRange, autosaveLabel, toastXInput, toastYInput, keybindsTable, hardResetBtn, toastWrap} from './ui.js';
-import {player, buildings, rectsIntersect, totalWeight, invAdd, teleportHome, upgrades, priceFor, buy, sellItem, sellAll, inventoryValue, ASCENSION_BUILDING, ascend, softReset} from './player.js';
+import {canvas, ctx, statsEl, say, closeAllModals, closeModal, isUIOpen, openInventory, openShop, openMarket, marketModal, saveBtn, loadBtn, loadInput, staminaBar, staminaFill, weightBar, weightFill, openModal, ascendModal, ascendBtn, settingsBtn, settingsModal, autosaveRange, autosaveLabel, toastXInput, toastYInput, keybindsTable, hardResetBtn, toastWrap} from './ui.js';
+import {player, buildings, rectsIntersect, totalWeight, invAdd, teleportHome, upgrades, priceFor, buy, sellItem, sellAll, inventoryValue, ASCENSION_BUILDING, ascend} from './player.js';
 import {setupPages} from './pages.js';
 import {setupAscensionShop} from './ascension.js';
 import {saveGameToFile, loadGameFromString, saveGameToStorage, loadGameFromStorage, SAVE_KEY} from './save.js';
@@ -236,7 +236,6 @@ loadInput.onchange = e => {
 };
 
 ascendBtn.onclick = () => { if (ascend()) closeAllModals(); };
-softResetBtn.onclick = () => { if (softReset()) closeAllModals(); };
 
 settingsBtn.onclick = () => { renderKeybinds(); openModal(settingsModal); };
 

--- a/js/player.js
+++ b/js/player.js
@@ -120,7 +120,16 @@ function resetPlayerStats() {
 }
 
 export function ascend() {
-  if (player.cash < 10000) { say('Need $10000 to ascend.'); return false; }
+  if (player.cash < 10000) {
+    if (confirm('Not enough money to ascend. Ascend for no gain?')) {
+      softReset();
+      say('Ascended for no gain.');
+      return true;
+    } else {
+      say('Need $10000 to ascend.');
+      return false;
+    }
+  }
   player.ascensions++;
   player.ascensionPoints += player.ascensions;
   player.cash = 0;

--- a/js/ui.js
+++ b/js/ui.js
@@ -21,7 +21,6 @@ export const ascendBtn = document.getElementById('ascendBtn');
 export const ascShopBtn = document.getElementById('ascShopBtn');
 export const ascShopModal = document.getElementById('ascShopModal');
 export const ascShopBody = document.getElementById('ascShopBody');
-export const softResetBtn = document.getElementById('softResetBtn');
 export const settingsBtn = document.getElementById('settingsBtn');
 export const settingsModal = document.getElementById('settingsModal');
 export const settingsClose = document.getElementById('settingsClose');


### PR DESCRIPTION
## Summary
- Remove dedicated Soft Reset button and related code
- Allow Ascend to offer a no-gain reset when insufficient funds
- Update ascension modal text accordingly

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68964c4fe05c8330b6d08125e259a9dc