### PR TITLE
Improve forge smelting and upgrade

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -1,7 +1,7 @@
 import {TILE, MAP_W, MAP_H, MOVE_ACC, GRAV, FRICTION} from './config.js';
 import {MATERIALS, BAR_MAP} from './materials.js';
 import {world, worldToTile, isSolidAt, generateWorld} from './world.js';
-import {canvas, ctx, statsEl, say, closeAllModals, closeModal, isUIOpen, openInventory, openShop, openMarket, marketModal, saveBtn, loadBtn, loadInput, staminaBar, staminaFill, weightBar, weightFill, openModal, ascendModal, ascendBtn, settingsBtn, settingsModal, autosaveRange, autosaveLabel, toastXInput, toastYInput, keybindsTable, hardResetBtn, toastWrap, ascendCostText, openBuilder, openForge, openWarehouse} from './ui.js';
+import {canvas, ctx, statsEl, say, closeAllModals, closeModal, isUIOpen, openInventory, openShop, openMarket, marketModal, saveBtn, loadBtn, loadInput, staminaBar, staminaFill, weightBar, weightFill, openModal, ascendModal, ascendBtn, settingsBtn, settingsModal, autosaveRange, autosaveLabel, toastXInput, toastYInput, keybindsTable, hardResetBtn, toastWrap, ascendCostText, openBuilder, openForge, openWarehouse, renderForge, forgeModal} from './ui.js';
 import {player, buildings, rectsIntersect, totalWeight, invAdd, teleportHome, upgrades, priceFor, buy, sellItem, sellAll, inventoryValue, ASCENSION_BUILDING, ascend, ascensionCost, BUILDING_COSTS, contributeBuilding, queueSmelt, storeInWarehouse, takeFromWarehouse} from './player.js';
 import {setupPages} from './pages.js';
 import {setupAscensionShop} from './ascension.js';
@@ -125,7 +125,11 @@ function resolveCollisions() {
 const camera = { x: 0, y: 0 };
 
 function updateForge() {
-  if (player.forgeQueue.length === 0) return;
+  if (player.forgeQueue.length === 0) {
+    if (!forgeModal.classList.contains('hidden'))
+      renderForge(player, MATERIALS, BAR_MAP, queueSmelt);
+    return;
+  }
   const job = player.forgeQueue[0];
   job.time -= 1 / 60;
   if (job.time <= 0) {
@@ -134,6 +138,8 @@ function updateForge() {
     player.forgeQueue.shift();
     say('Smelted ' + MATERIALS[barId].name + '.');
   }
+  if (!forgeModal.classList.contains('hidden'))
+    renderForge(player, MATERIALS, BAR_MAP, queueSmelt);
 }
 
 function tick() {

--- a/js/materials.js
+++ b/js/materials.js
@@ -25,7 +25,7 @@ for (const mat of base) {
     color: mat.color,
     solid: false,
     hard: 0,
-    value: mat.value * 3,
+    value: mat.value * 5,
     weight: mat.weight,
     barFor: mat.id
   };

--- a/js/player.js
+++ b/js/player.js
@@ -113,7 +113,10 @@ export function sellAll() {
 export const BUILDING_COSTS = {
   forge: { materials: { 5: 50, 3: 50 }, cash: 5000 },
   warehouse: { materials: { [BAR_MAP[5]]: 50, 3: 100 }, cash: 0 },
-  forgeUpgrade: { materials: { [BAR_MAP[5]]: 50 }, cash: 10000 }
+  forgeUpgrade: {
+    materials: { [BAR_MAP[5]]: 3, [BAR_MAP[4]]: 5, [BAR_MAP[6]]: 1 },
+    cash: 10000
+  }
 };
 
 export function contributeBuilding(kind) {
@@ -152,7 +155,7 @@ export function queueSmelt(oreId) {
   const taken = removeFromInventory(oreId, 10);
   if (taken < 10) { if (taken > 0) invAdd(oreId, taken); say('Need 10 ore.'); return; }
   const time = 10 / Math.pow(2, Math.max(player.forgeLevel - 1, 0));
-  player.forgeQueue.push({ id: oreId, time });
+  player.forgeQueue.push({ id: oreId, time, total: time });
   say('Smelting started.');
 }
 

--- a/js/save.js
+++ b/js/save.js
@@ -35,7 +35,7 @@ export function loadGameFromString(b64) {
     player.ascensionPoints = state.player.ascensionPoints || 0;
     player.buildingProgress = state.player.buildingProgress || {};
     player.forgeLevel = state.player.forgeLevel || 0;
-    player.forgeQueue = state.player.forgeQueue || [];
+    player.forgeQueue = (state.player.forgeQueue || []).map(j => ({ total: j.total || j.time || 0, ...j }));
     player.warehouse = state.player.warehouse || [];
     buildings.length = 0;
     if (Array.isArray(state.buildings)) {

--- a/js/ui.js
+++ b/js/ui.js
@@ -196,12 +196,24 @@ export function renderForge(player, MATERIALS, BAR_MAP, queueSmelt) {
       <button data-id='${it.id}' class='smelt px-3 py-1.5 rounded-md border border-slate-600'>Smelt</button>
     </div>`;
   }).join('');
+  let progressHTML = '';
+  if (player.forgeQueue.length > 0) {
+    const job = player.forgeQueue[0];
+    const m = MATERIALS[job.id];
+    const bar = MATERIALS[BAR_MAP[job.id]];
+    const total = job.total || 1;
+    const ratio = 1 - job.time / total;
+    progressHTML = `<div class='mb-2'>
+      <div class='text-xs mb-1'>Smelting ${m.name} → ${bar.name}</div>
+      <div class='w-full h-2 bg-slate-700 rounded overflow-hidden'><div class='h-full bg-amber-500' style='width:${(ratio * 100).toFixed(1)}%'></div></div>
+    </div>`;
+  }
   const queueLines = player.forgeQueue.map((job, i) => {
     const m = MATERIALS[job.id];
     const bar = MATERIALS[BAR_MAP[job.id]];
     return `<div class='text-xs'>${i + 1}. ${m.name} → ${bar.name}: ${job.time.toFixed(1)}s</div>`;
   }).join('');
-  forgeBody.innerHTML = oreLines + `<div class='mt-4'><div class='font-medium mb-1'>Queue</div>${queueLines || '<div class="text-xs text-slate-400">(empty)</div>'}</div>`;
+  forgeBody.innerHTML = oreLines + progressHTML + `<div class='mt-4'><div class='font-medium mb-1'>Queue</div>${queueLines || '<div class="text-xs text-slate-400">(empty)</div>'}</div>`;
   forgeBody.querySelectorAll('button.smelt').forEach(btn => {
     btn.onclick = () => { queueSmelt(+btn.getAttribute('data-id')); renderForge(player, MATERIALS, BAR_MAP, queueSmelt); };
   });


### PR DESCRIPTION
## Summary
- Make bar value 5× the ore value
- Adjust first forge upgrade cost (3 iron bars, 5 copper bars, 1 gold bar, $10k)
- Queue smelting with live progress bar and continuous updates

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6896598469b08330bb840a63fb156b55