### PR TITLE
Fix reset mechanics (ascension / soft / hard reset)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -121,36 +121,40 @@ render hub. Note a small cycle-ish coupling: `world.ts` imports `applyPageModifi
   page is equipped mid-run. Equipping then expecting an immediate spawn-rate change is a common
   confusion.
 
-## Known issues & rough edges (the newer mechanics — where dev stalled)
-These are the concentration of half-wired/unbalanced logic in the newest feature clusters (Forge/
-Warehouse + the gravity/mining revamp). Verified against current source. **Not yet fixed** — treat
-as the backlog for picking dev back up.
+## Reset semantics (Stage 5.1 — fixed)
+Three reset paths, now with defined behaviour:
+- **Ascension / soft reset** (`ascend()`/`softReset()`, `js/player.ts`) — a **full run reset**.
+  `resetPlayerStats()` rebuilds `player` from a fresh clone and restores only the fields in
+  `PERSIST_ACROSS_ASCENSION` (ascension count/points/upgrades, pages, `holdToMine`). Forge, Warehouse,
+  warehouse contents, cash, inventory, shop-upgrade stats, and the world all reset by design. **To make
+  something survive a future upgrade, add its key to `PERSIST_ACROSS_ASCENSION` (conditionally) and
+  rebuild it in `rebuildWorldAndBuildings()`** — that's the intended extension point.
+- **Hard reset** (Settings, `js/main.ts`) — **progress only**: clears the save and reloads to a fresh
+  game, but keeps keybinds and UI settings. It first removes the `beforeunload`/autosave handlers so
+  the cleared state isn't re-persisted (the old bug: the mine never changed).
+- `player` is built with `freshPlayer()` (`structuredClone`) so it never shares array refs with
+  `BASE_PLAYER` — resets are clean and the template can't be polluted. Covered by `test/reset.test.ts`.
 
-1. **Ascension wipes buildings AND warehouse contents.** `resetPlayerStats()` (`js/player.ts:198`,
-   marked with a `TODO(stage5)`) preserves only ascension/pages/upgrade fields — it does **not** keep
-   `warehouse`, `forgeLevel`, `forgeQueue`, or `buildingProgress`. Then `ascend()`/`softReset()` reset
-   `buildings` to `BASE_BUILDINGS` (`js/player.ts:231`, `:248`). Net: every prestige destroys the Forge, the
-   Warehouse, and everything stored in it. A storage building that empties on the core reset loop
-   fights the meta-progression — likely the "Forge/Warehouse feels broken" memory. *Fix direction:*
-   decide what should persist across ascension (probably warehouse + built buildings) and preserve
-   it in `resetPlayerStats` + rebuild those buildings.
-2. **Balance / progression pacing.** Several economy knobs trend to degenerate: Forge Upgrade has
+## Known issues & rough edges (backlog)
+Remaining half-wired/unbalanced logic, **not yet fixed**:
+
+1. **Balance / progression pacing.** Several economy knobs trend to degenerate: Forge Upgrade has
    **no max level** so smelt time `10/2^(level-1)` (`js/player.ts:159`) → ~0; Warehouse has **no
    capacity cap** (`storeInWarehouse` pulls `Infinity`, `js/player.ts:164`). Worth a deliberate pass
    on ascension cost curve, upgrade caps, and bar/ore values (`materials.ts`).
-3. **Dead stamina regen.** `player.staminaRegen` is never read in the loop — stamina only refills on
+2. **Dead stamina regen.** `player.staminaRegen` is never read in the loop — stamina only refills on
    teleport-home. The ascension upgrade **"2x Stamina Gain"** (`js/ascension.ts:23`) therefore does
    nothing. *Fix direction:* add `player.stamina = min(max, stamina + staminaRegen*…)` in `tick()`.
-4. **Uncapped fall speed → tunneling.** The gravity revamp removed the `vy` clamp; `resolveCollisions()`
+3. **Uncapped fall speed → tunneling.** The gravity revamp removed the `vy` clamp; `resolveCollisions()`
    (`js/main.ts:113`) does a single non-swept `y += vy` and only tests the destination cell. On long
    drops `vy` exceeds a tile (24px) and you tunnel through thin floors / the air pockets world-gen
    randomly punches (`js/world.ts:36`). *Fix direction:* cap `vy` to < `TILE`, or sweep the
    collision.
-5. **Forge UI re-renders 60×/second while open** (`js/main.ts:127` → `renderForge`), even with an
+4. **Forge UI re-renders 60×/second while open** (`js/main.ts:127` → `renderForge`), even with an
    empty queue — rebuilds `innerHTML` + rebinds handlers every frame. Wasteful; render on change.
-6. **All new buildings share one color.** `draw()` (`js/main.ts:209`) only special-cases shop
+5. **All new buildings share one color.** `draw()` (`js/main.ts:209`) only special-cases shop
    (blue) and market (purple); builder/forge/warehouse/ascension all render green.
-7. **Save format is unversioned.** `js/save.ts` `Object.assign(player, state.player)` loads any
+6. **Save format is unversioned.** `js/save.ts` `Object.assign(player, state.player)` loads any
    stored fields with no schema/version guard. Adding/removing `player` fields can silently corrupt
    old saves — add migration logic when you change the shape.
 

--- a/js/main.ts
+++ b/js/main.ts
@@ -328,10 +328,12 @@ toastYInput.oninput = () => {
 };
 
 hardResetBtn.onclick = () => {
-  if (confirm('Erase all save data?')) {
-    localStorage.removeItem(SAVE_KEY);
-    localStorage.removeItem('keybinds');
-    localStorage.removeItem('autosaveInterval');
+  if (confirm('Reset all game progress? Your keybinds and settings are kept.')) {
+    // Stop autosave and the unload save first, or they'd immediately re-persist the
+    // state we're about to clear and the reload would just restore it.
+    clearInterval(autosaveHandle);
+    removeEventListener('beforeunload', saveGameToStorage);
+    localStorage.removeItem(SAVE_KEY); // progress only — keybinds/autosave/toast settings kept
     location.reload();
   }
 };

--- a/js/player.ts
+++ b/js/player.ts
@@ -39,7 +39,18 @@ const BASE_PLAYER: Player = {
   warehouse: []
 };
 
-export const player: Player = { ...BASE_PLAYER };
+// Deep copy so `player` never shares array/object references with BASE_PLAYER —
+// otherwise gameplay mutations would pollute the template and resets wouldn't be clean.
+function freshPlayer(): Player { return structuredClone(BASE_PLAYER); }
+
+export const player: Player = freshPlayer();
+
+// The only state that survives an ascension. Everything else resets to a fresh player.
+// Future upgrades will conditionally extend this (e.g. keep buildings/warehouse).
+const PERSIST_ACROSS_ASCENSION = [
+  'ascensions', 'ascensionUnlocked', 'holdToMine',
+  'pages', 'equippedPages', 'ascensionPoints', 'ascensionUpgrades',
+] as const satisfies readonly (keyof Player)[];
 
 export const BASE_BUILDINGS: Building[] = [
   { x: TILE * 8,  y: TILE * 5 - TILE * 2, w: TILE * 3, h: TILE * 2, kind: 'shop',    name: 'Shop' },
@@ -196,15 +207,25 @@ export function teleportHome() {
 }
 
 function resetPlayerStats() {
-  // TODO(stage5): this preserves only ascension/pages/upgrade fields — it drops
-  // warehouse, forgeLevel, forgeQueue, and buildingProgress. Combined with the
-  // buildings reset in ascend()/softReset(), every prestige destroys the Forge,
-  // the Warehouse, and everything stored in it. Decide an explicit
-  // persist-across-ascension boundary and keep those fields.
-  const { ascensions, ascensionUnlocked, holdToMine, pages, equippedPages, ascensionPoints, ascensionUpgrades } = player;
-  Object.assign(player, { ...BASE_PLAYER, ascensions, ascensionUnlocked, holdToMine, pages, equippedPages, ascensionPoints, ascensionUpgrades });
-  player.inventory = [];
+  // Reset to a pristine player, then restore only the fields that survive an ascension.
+  const preserved: Partial<Player> = {};
+  for (const key of PERSIST_ACROSS_ASCENSION) preserved[key] = player[key] as never;
+  Object.assign(player, freshPlayer(), preserved);
   applyAscensionUpgrades(player);
+}
+
+// Shared by ascend() and softReset(): regenerate the world and rebuild the surface
+// buildings. Forge/Warehouse are intentionally NOT re-added — they reset with the run.
+// (Future persist-upgrades will extend PERSIST_ACROSS_ASCENSION and rebuild buildings here.)
+function rebuildWorldAndBuildings() {
+  generateWorld(player.ascensions, player.equippedPages);
+  buildings.length = 0;
+  buildings.push(...BASE_BUILDINGS);
+  if (player.ascensionUnlocked || player.ascensions > 0) {
+    player.ascensionUnlocked = true;
+    buildings.push({ ...ASCENSION_BUILDING });
+  }
+  teleportHome();
 }
 
 export function ascensionCost() {
@@ -227,14 +248,7 @@ export function ascend() {
   player.ascensionPoints += player.ascensions;
   player.cash = 0;
   resetPlayerStats();
-  generateWorld(player.ascensions, player.equippedPages);
-  buildings.length = 0;
-  buildings.push(...BASE_BUILDINGS);
-  if (player.ascensionUnlocked || player.ascensions > 0) {
-    player.ascensionUnlocked = true;
-    buildings.push({ ...ASCENSION_BUILDING });
-  }
-  teleportHome();
+  rebuildWorldAndBuildings();
   const pg = awardRandomPage(player);
   say('The world has been reborn.');
   say('Gained ' + player.ascensions + ' ascension points.');
@@ -244,14 +258,7 @@ export function ascend() {
 
 export function softReset() {
   resetPlayerStats();
-  generateWorld(player.ascensions, player.equippedPages);
-  buildings.length = 0;
-  buildings.push(...BASE_BUILDINGS);
-  if (player.ascensionUnlocked || player.ascensions > 0) {
-    player.ascensionUnlocked = true;
-    buildings.push({ ...ASCENSION_BUILDING });
-  }
-  teleportHome();
+  rebuildWorldAndBuildings();
   say('The world has been refreshed.');
   return true;
 }

--- a/test/reset.test.ts
+++ b/test/reset.test.ts
@@ -1,0 +1,80 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import {
+  player, buildings, softReset, ascend, ascensionCost, invAdd, storeInWarehouse,
+} from '../js/player';
+
+// Normalise the shared player singleton before each case.
+function baseState() {
+  Object.assign(player, {
+    ascensions: 0, ascensionUnlocked: false, ascensionPoints: 0,
+    cash: 0, forgeLevel: 0, pickPower: 2, carryCap: 40,
+  });
+  player.ascensionUpgrades = {};
+  player.pages = {};
+  player.equippedPages = {};
+  player.inventory = [];
+  player.warehouse = [];
+  player.forgeQueue = [];
+  player.buildingProgress = {};
+}
+beforeEach(baseState);
+
+describe('reset mechanics', () => {
+  it('softReset clears run state but keeps meta-progression', () => {
+    // meta that must survive
+    player.ascensions = 3;
+    player.ascensionUpgrades = { drill_range: true };
+    player.pages = { copper_spawn: { 1: 2 } };
+    // run state that must clear
+    player.cash = 999;
+    player.pickPower = 8;
+    invAdd(4, 20);
+    storeInWarehouse(4);
+    player.forgeLevel = 3;
+    player.forgeQueue.push({ id: 4, time: 5, total: 10 });
+    player.buildingProgress = { forge: { materials: {}, cash: 100 } };
+
+    softReset();
+
+    expect(player.ascensions).toBe(3);
+    expect(player.ascensionUpgrades).toEqual({ drill_range: true });
+    expect(player.pages).toEqual({ copper_spawn: { 1: 2 } });
+
+    expect(player.cash).toBe(0);
+    expect(player.inventory).toEqual([]);
+    expect(player.warehouse).toEqual([]);
+    expect(player.forgeLevel).toBe(0);
+    expect(player.forgeQueue).toEqual([]);
+    expect(player.buildingProgress).toEqual({});
+    expect(player.pickPower).toBe(2); // shop-upgrade stat back to base
+  });
+
+  it('each reset yields fresh arrays — no BASE_PLAYER aliasing/accumulation', () => {
+    invAdd(5, 5);
+    storeInWarehouse(5);
+    softReset();
+    expect(player.warehouse).toEqual([]);
+
+    const invRef = player.inventory;
+    invAdd(6, 3);          // mutate the current array
+    softReset();
+    expect(player.inventory).toEqual([]);      // cleared again
+    expect(player.inventory).not.toBe(invRef); // and it's a brand-new array
+  });
+
+  it('ascend at affordable cost resets the run and rebuilds base buildings only', () => {
+    player.cash = ascensionCost(); // 10000 at ascensions 0
+    invAdd(4, 10);
+    player.forgeLevel = 1;
+
+    expect(ascend()).toBe(true);
+
+    expect(player.ascensions).toBe(1);
+    expect(player.cash).toBe(0);
+    expect(player.inventory).toEqual([]);
+    expect(player.forgeLevel).toBe(0);
+    expect(buildings.some(b => b.kind === 'forge')).toBe(false);
+    expect(buildings.some(b => b.kind === 'warehouse')).toBe(false);
+    expect(buildings.some(b => b.kind === 'ascension')).toBe(true); // unlocked post-ascension
+  });
+});


### PR DESCRIPTION
Fixes the broken reset paths flagged during Stage 5 planning. No new gameplay features — makes the existing resets behave correctly.

## Bugs fixed
1. **Hard reset didn't clear the mine.** The `beforeunload` autosave re-wrote the state right after Hard Reset cleared it, so the reload restored the old world. Now the unload/autosave handlers are removed before reload. Verified in-browser: world signature changes on hard reset (previously identical).
2. **State aliasing.** `player` was a shallow `{...BASE_PLAYER}`, so `inventory`/`warehouse`/`forgeQueue`/`buildingProgress` shared array refs with the template — gameplay polluted `BASE_PLAYER` and resets were inconsistent (the "Forge/Warehouse feels broken" symptom). Now built via `structuredClone`.

## Behaviour (per design decisions)
- **Ascension / soft reset** = full run reset; only `PERSIST_ACROSS_ASCENSION` (ascension count/points/upgrades, pages, `holdToMine`) survives. Single, explicit extension point for future persist-upgrades. `ascend()`/`softReset()` now share `rebuildWorldAndBuildings()`.
- **Hard reset** = progress-only: clears the save, keeps keybinds + UI settings. Verified in-browser (keybinds/toast position survive).

## Tests
`test/reset.test.ts` (3 new): meta preserved + run state cleared, no `BASE_PLAYER` aliasing, `ascend()` rebuilds base buildings only. Full suite 24/24; typecheck clean; build OK.

## Notes for the future upgrade layer
To make something survive ascension later, add its key to `PERSIST_ACROSS_ASCENSION` (conditionally) and rebuild it in `rebuildWorldAndBuildings()`.