### PR TITLE
Wire up stamina regen system (inert by default)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -135,6 +135,15 @@ Three reset paths, now with defined behaviour:
 - `player` is built with `freshPlayer()` (`structuredClone`) so it never shares array refs with
   `BASE_PLAYER` — resets are clean and the template can't be polluted. Covered by `test/reset.test.ts`.
 
+## Stamina regen (wired, currently off)
+`regenStamina(seconds)` (`js/player.ts`) is called every frame from `tick()` as `regenStamina(1/60)`.
+`player.staminaRegen` is measured in **stamina per second** and defaults to **0**, so there's no
+passive regen yet — stamina still only drains (3/swing) and refills on teleport-home / Lungs. To
+enable it, set a non-zero `staminaRegen` (start small; 100 pool, 3/swing). The "2x Stamina Gain"
+ascension upgrade multiplies it (inert while the base is 0). Regen currently applies unconditionally
+each frame; idle-only / not-while-mining gating is a future balance lever. Covered by
+`test/stamina.test.ts`.
+
 ## Known issues & rough edges (backlog)
 Remaining half-wired/unbalanced logic, **not yet fixed**:
 
@@ -142,19 +151,16 @@ Remaining half-wired/unbalanced logic, **not yet fixed**:
    **no max level** so smelt time `10/2^(level-1)` (`js/player.ts:159`) → ~0; Warehouse has **no
    capacity cap** (`storeInWarehouse` pulls `Infinity`, `js/player.ts:164`). Worth a deliberate pass
    on ascension cost curve, upgrade caps, and bar/ore values (`materials.ts`).
-2. **Dead stamina regen.** `player.staminaRegen` is never read in the loop — stamina only refills on
-   teleport-home. The ascension upgrade **"2x Stamina Gain"** (`js/ascension.ts:23`) therefore does
-   nothing. *Fix direction:* add `player.stamina = min(max, stamina + staminaRegen*…)` in `tick()`.
-3. **Uncapped fall speed → tunneling.** The gravity revamp removed the `vy` clamp; `resolveCollisions()`
+2. **Uncapped fall speed → tunneling.** The gravity revamp removed the `vy` clamp; `resolveCollisions()`
    (`js/main.ts:113`) does a single non-swept `y += vy` and only tests the destination cell. On long
    drops `vy` exceeds a tile (24px) and you tunnel through thin floors / the air pockets world-gen
    randomly punches (`js/world.ts:36`). *Fix direction:* cap `vy` to < `TILE`, or sweep the
    collision.
-4. **Forge UI re-renders 60×/second while open** (`js/main.ts:127` → `renderForge`), even with an
+3. **Forge UI re-renders 60×/second while open** (`js/main.ts:127` → `renderForge`), even with an
    empty queue — rebuilds `innerHTML` + rebinds handlers every frame. Wasteful; render on change.
-5. **All new buildings share one color.** `draw()` (`js/main.ts:209`) only special-cases shop
+4. **All new buildings share one color.** `draw()` (`js/main.ts:209`) only special-cases shop
    (blue) and market (purple); builder/forge/warehouse/ascension all render green.
-6. **Save format is unversioned.** `js/save.ts` `Object.assign(player, state.player)` loads any
+5. **Save format is unversioned.** `js/save.ts` `Object.assign(player, state.player)` loads any
    stored fields with no schema/version guard. Adding/removing `player` fields can silently corrupt
    old saves — add migration logic when you change the shape.
 

--- a/js/ascension.ts
+++ b/js/ascension.ts
@@ -26,7 +26,7 @@ export const ASCENSION_UPGRADES: AscensionUpgrade[] = [
     cost: 2,
     tier: 1,
     requires: ['drill_range'],
-    apply: p => { p.staminaRegen = (p.staminaRegen || 1) * 2; }
+    apply: p => { p.staminaRegen *= 2; } // no-op while base regen is 0; scales it once set
   },
   {
     id: 'mine_up',

--- a/js/main.ts
+++ b/js/main.ts
@@ -2,7 +2,7 @@ import {TILE, MAP_W, MAP_H, MOVE_ACC, GRAV, FRICTION} from './config';
 import {MATERIALS, BAR_MAP} from './materials';
 import {world, worldToTile, isSolidAt, generateWorld} from './world';
 import {canvas, ctx, statsEl, say, closeAllModals, closeModal, isUIOpen, openInventory, openShop, openMarket, marketModal, saveBtn, loadBtn, loadInput, staminaBar, staminaFill, weightBar, weightFill, openModal, ascendModal, ascendBtn, settingsBtn, settingsModal, autosaveRange, autosaveLabel, toastXInput, toastYInput, keybindsTable, hardResetBtn, toastWrap, ascendCostText, openBuilder, openForge, openWarehouse, renderForge, forgeModal} from './ui';
-import {player, buildings, rectsIntersect, totalWeight, invAdd, teleportHome, upgrades, priceFor, buy, sellItem, sellAll, inventoryValue, ASCENSION_BUILDING, ascend, ascensionCost, BUILDING_COSTS, contributeBuilding, queueSmelt, storeInWarehouse, takeFromWarehouse} from './player';
+import {player, buildings, rectsIntersect, totalWeight, invAdd, teleportHome, upgrades, priceFor, buy, sellItem, sellAll, inventoryValue, ASCENSION_BUILDING, ascend, ascensionCost, BUILDING_COSTS, contributeBuilding, queueSmelt, storeInWarehouse, takeFromWarehouse, regenStamina} from './player';
 import {setupPages} from './pages';
 import {setupAscensionShop} from './ascension';
 import {saveGameToFile, loadGameFromString, saveGameToStorage, loadGameFromStorage, SAVE_KEY} from './save';
@@ -181,6 +181,7 @@ function tick() {
   player.vy += GRAV;
   player.vx *= FRICTION;
   resolveCollisions();
+  regenStamina(1 / 60); // ~60fps; same seconds-per-frame convention as the forge
   updateForge();
 
   if (!player.ascensionUnlocked && Math.floor((player.y + player.h) / TILE) >= MAP_H - 1) {

--- a/js/player.ts
+++ b/js/player.ts
@@ -30,7 +30,7 @@ const BASE_PLAYER: Player = {
   ascensionUnlocked: false,
   ascensionPoints: 0,
   ascensionUpgrades: {},
-  staminaRegen: 1,
+  staminaRegen: 0, // stamina/sec. 0 = no passive regen (deliberately off until tuned).
   holdToMine: false,
   mineUp: false,
   buildingProgress: {},
@@ -64,6 +64,12 @@ export const WAREHOUSE_BUILDING: Building = { x: TILE * 33, y: TILE * 5 - TILE *
 export const ASCENSION_BUILDING: Building = { x: TILE * 23, y: TILE * 5 - TILE * 2, w: TILE * 3, h: TILE * 2, kind: 'ascension', name: 'Ascension' };
 
 export const buildings: Building[] = BASE_BUILDINGS.slice();
+
+// Passive stamina recovery. `staminaRegen` is stamina-per-second; callers pass the
+// elapsed seconds for the frame. No-op while staminaRegen is 0 (the current default).
+export function regenStamina(seconds: number) {
+  player.stamina = Math.min(player.staminaMax, player.stamina + player.staminaRegen * seconds);
+}
 
 type Rect = { x: number; y: number; w: number; h: number };
 export function rectsIntersect(a: Rect, b: Rect) {

--- a/test/stamina.test.ts
+++ b/test/stamina.test.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { player, regenStamina } from '../js/player';
+import { ASCENSION_UPGRADES } from '../js/ascension';
+
+beforeEach(() => {
+  player.staminaMax = 100;
+  player.stamina = 50;
+  player.staminaRegen = 0;
+});
+
+describe('regenStamina', () => {
+  it('adds staminaRegen * seconds (per-second units)', () => {
+    player.staminaRegen = 6;
+    regenStamina(1);
+    expect(player.stamina).toBe(56);
+  });
+
+  it('scales with the elapsed seconds', () => {
+    player.staminaRegen = 6;
+    regenStamina(0.5);
+    expect(player.stamina).toBe(53); // 50 + 6*0.5
+  });
+
+  it('caps at staminaMax', () => {
+    player.stamina = 99;
+    player.staminaRegen = 20;
+    regenStamina(1);
+    expect(player.stamina).toBe(100);
+  });
+
+  it('is a no-op when staminaRegen is 0 (the default)', () => {
+    regenStamina(1);
+    expect(player.stamina).toBe(50);
+  });
+});
+
+describe('"2x Stamina Gain" ascension upgrade', () => {
+  const staminaGain = ASCENSION_UPGRADES.find(u => u.id === 'stamina_gain')!;
+
+  it('doubles a non-zero base regen', () => {
+    player.staminaRegen = 5;
+    staminaGain.apply(player);
+    expect(player.staminaRegen).toBe(10);
+  });
+
+  it('stays 0 when base regen is 0 (no accidental resurrection)', () => {
+    player.staminaRegen = 0;
+    staminaGain.apply(player);
+    expect(player.staminaRegen).toBe(0);
+  });
+});


### PR DESCRIPTION
Builds the passive stamina-regen pathway but ships it **off** (`staminaRegen = 0`), so zero balance impact until tuned. Also fixes the dead "2x Stamina Gain" ascension upgrade.

(Re-opened as a fresh PR — original #33 auto-closed when its stacked base branch was deleted on merge of #32. Same commit.)

## Changes
- `regenStamina(seconds)` in `player.ts` (stamina/sec, capped) called each frame from `tick()`.
- `staminaRegen` defaults to **0** → no passive regen yet.
- Ascension "2x Stamina Gain" now `*= 2` (was `(x || 1) * 2`).

## Verified (Playwright)
- Default 0: stamina held steady (no regen). At 5/sec: climbed ~5/sec. 30/30 tests, typecheck clean, build OK.