### PR TITLE
Fix fall-through tunneling with swept collision

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -144,6 +144,14 @@ ascension upgrade multiplies it (inert while the base is 0). Regen currently app
 each frame; idle-only / not-while-mining gating is a future balance lever. Covered by
 `test/stamina.test.ts`.
 
+## Collision / falling (fixed)
+Player movement is resolved by `resolvePlayerMovement(player, isSolidAt)` in `js/physics.ts`, called
+from `resolveCollisions()` in `tick()`. It **sweeps** the move in sub-steps of `TILE*0.5` and runs the
+edge checks each sub-step, so fast falls can't tunnel through thin floors / air pockets. **Fall speed
+stays uncapped** by design (respecting the gravity revamp) — sub-stepping fixes tunneling without
+limiting velocity. Slow movement (|v| ≤ half a tile) runs as a single step, identical to before.
+Covered by `test/physics.test.ts` (incl. a `vy=300` no-tunnel regression).
+
 ## Known issues & rough edges (backlog)
 Remaining half-wired/unbalanced logic, **not yet fixed**:
 
@@ -151,16 +159,11 @@ Remaining half-wired/unbalanced logic, **not yet fixed**:
    **no max level** so smelt time `10/2^(level-1)` (`js/player.ts:159`) → ~0; Warehouse has **no
    capacity cap** (`storeInWarehouse` pulls `Infinity`, `js/player.ts:164`). Worth a deliberate pass
    on ascension cost curve, upgrade caps, and bar/ore values (`materials.ts`).
-2. **Uncapped fall speed → tunneling.** The gravity revamp removed the `vy` clamp; `resolveCollisions()`
-   (`js/main.ts:113`) does a single non-swept `y += vy` and only tests the destination cell. On long
-   drops `vy` exceeds a tile (24px) and you tunnel through thin floors / the air pockets world-gen
-   randomly punches (`js/world.ts:36`). *Fix direction:* cap `vy` to < `TILE`, or sweep the
-   collision.
-3. **Forge UI re-renders 60×/second while open** (`js/main.ts:127` → `renderForge`), even with an
+2. **Forge UI re-renders 60×/second while open** (`js/main.ts:127` → `renderForge`), even with an
    empty queue — rebuilds `innerHTML` + rebinds handlers every frame. Wasteful; render on change.
-4. **All new buildings share one color.** `draw()` (`js/main.ts:209`) only special-cases shop
+3. **All new buildings share one color.** `draw()` (`js/main.ts:209`) only special-cases shop
    (blue) and market (purple); builder/forge/warehouse/ascension all render green.
-5. **Save format is unversioned.** `js/save.ts` `Object.assign(player, state.player)` loads any
+4. **Save format is unversioned.** `js/save.ts` `Object.assign(player, state.player)` loads any
    stored fields with no schema/version guard. Adding/removing `player` fields can silently corrupt
    old saves — add migration logic when you change the shape.
 

--- a/js/main.ts
+++ b/js/main.ts
@@ -1,6 +1,7 @@
 import {TILE, MAP_W, MAP_H, MOVE_ACC, GRAV, FRICTION} from './config';
 import {MATERIALS, BAR_MAP} from './materials';
 import {world, worldToTile, isSolidAt, generateWorld} from './world';
+import {resolvePlayerMovement} from './physics';
 import {canvas, ctx, statsEl, say, closeAllModals, closeModal, isUIOpen, openInventory, openShop, openMarket, marketModal, saveBtn, loadBtn, loadInput, staminaBar, staminaFill, weightBar, weightFill, openModal, ascendModal, ascendBtn, settingsBtn, settingsModal, autosaveRange, autosaveLabel, toastXInput, toastYInput, keybindsTable, hardResetBtn, toastWrap, ascendCostText, openBuilder, openForge, openWarehouse, renderForge, forgeModal} from './ui';
 import {player, buildings, rectsIntersect, totalWeight, invAdd, teleportHome, upgrades, priceFor, buy, sellItem, sellAll, inventoryValue, ASCENSION_BUILDING, ascend, ascensionCost, BUILDING_COSTS, contributeBuilding, queueSmelt, storeInWarehouse, takeFromWarehouse, regenStamina} from './player';
 import {setupPages} from './pages';
@@ -99,27 +100,7 @@ function tryMine() {
 }
 
 function resolveCollisions() {
-  player.x += player.vx;
-  if (player.vx > 0) {
-    if (isSolidAt(player.x + player.w, player.y) || isSolidAt(player.x + player.w, player.y + player.h - 1)) {
-      player.x = Math.floor((player.x + player.w) / TILE) * TILE - player.w - 0.01; player.vx = 0;
-    }
-  } else if (player.vx < 0) {
-    if (isSolidAt(player.x, player.y) || isSolidAt(player.x, player.y + player.h - 1)) {
-      player.x = Math.floor(player.x / TILE + 1) * TILE + 0.01; player.vx = 0;
-    }
-  }
-
-  player.y += player.vy; player.onGround = false;
-  if (player.vy > 0) {
-    if (isSolidAt(player.x + 1, player.y + player.h) || isSolidAt(player.x + player.w - 1, player.y + player.h)) {
-      player.y = Math.floor((player.y + player.h) / TILE) * TILE - player.h - 0.01; player.vy = 0; player.onGround = true;
-    }
-  } else if (player.vy < 0) {
-    if (isSolidAt(player.x + 1, player.y) || isSolidAt(player.x + player.w - 1, player.y)) {
-      player.y = Math.floor(player.y / TILE + 1) * TILE + 0.01; player.vy = 0;
-    }
-  }
+  resolvePlayerMovement(player, isSolidAt);
 }
 
 const camera = { x: 0, y: 0 };

--- a/js/physics.ts
+++ b/js/physics.ts
@@ -1,0 +1,47 @@
+import { TILE } from './config';
+import type { Player } from './types';
+
+// Sub-step size for swept collision. Must be < TILE so a full tile can never be
+// skipped between checks; half a tile leaves comfortable margin.
+const MAX_STEP = TILE * 0.5;
+
+// Move the player by its velocity and resolve tile collisions, sweeping in
+// sub-steps so fast falls can't tunnel through thin floors. Slow movement
+// (|v| <= MAX_STEP) runs as a single step, identical to the naive version.
+// `isSolidAt(px, py)` reports whether a solid tile occupies that pixel.
+export function resolvePlayerMovement(p: Player, isSolidAt: (px: number, py: number) => boolean) {
+  const steps = Math.max(1, Math.ceil(Math.max(Math.abs(p.vx), Math.abs(p.vy)) / MAX_STEP));
+  const sx = p.vx / steps;
+  const sy = p.vy / steps;
+  p.onGround = false;
+
+  for (let i = 0; i < steps; i++) {
+    // Horizontal — skip once a wall has zeroed vx.
+    if (p.vx !== 0) {
+      p.x += sx;
+      if (p.vx > 0) {
+        if (isSolidAt(p.x + p.w, p.y) || isSolidAt(p.x + p.w, p.y + p.h - 1)) {
+          p.x = Math.floor((p.x + p.w) / TILE) * TILE - p.w - 0.01; p.vx = 0;
+        }
+      } else {
+        if (isSolidAt(p.x, p.y) || isSolidAt(p.x, p.y + p.h - 1)) {
+          p.x = Math.floor(p.x / TILE + 1) * TILE + 0.01; p.vx = 0;
+        }
+      }
+    }
+
+    // Vertical — skip once floor/ceiling has zeroed vy.
+    if (p.vy !== 0) {
+      p.y += sy;
+      if (p.vy > 0) {
+        if (isSolidAt(p.x + 1, p.y + p.h) || isSolidAt(p.x + p.w - 1, p.y + p.h)) {
+          p.y = Math.floor((p.y + p.h) / TILE) * TILE - p.h - 0.01; p.vy = 0; p.onGround = true;
+        }
+      } else {
+        if (isSolidAt(p.x + 1, p.y) || isSolidAt(p.x + p.w - 1, p.y)) {
+          p.y = Math.floor(p.y / TILE + 1) * TILE + 0.01; p.vy = 0;
+        }
+      }
+    }
+  }
+}

--- a/test/physics.test.ts
+++ b/test/physics.test.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect } from 'vitest';
+import { resolvePlayerMovement } from '../js/physics';
+import type { Player } from '../js/types';
+
+// Minimal player double with just the fields the physics touches.
+const mk = (o: Partial<Player>): Player =>
+  ({ x: 0, y: 0, w: 16, h: 22, vx: 0, vy: 0, onGround: false, ...o } as unknown as Player);
+
+// A one-tile-thick floor spanning row 10 (pixels y in [240, 264)).
+const floorRow10 = (_px: number, py: number) => Math.floor(py / 24) === 10;
+// A full-height wall in column 5 (pixels x in [120, 144)).
+const wallCol5 = (px: number, _py: number) => Math.floor(px / 24) === 5;
+
+describe('swept collision — resolvePlayerMovement', () => {
+  it('does NOT tunnel through a thin floor on a fast fall', () => {
+    const p = mk({ y: 0, vy: 300 }); // one naive step would jump feet to y=322, past the floor
+    resolvePlayerMovement(p, floorRow10);
+    expect(p.y).toBeCloseTo(240 - p.h - 0.01, 2); // resting on top of the floor
+    expect(p.vy).toBe(0);
+    expect(p.onGround).toBe(true);
+    expect(p.y + p.h).toBeLessThanOrEqual(240); // never crossed into the floor
+  });
+
+  it('slow fall lands identically (single-step path)', () => {
+    const p = mk({ y: 216, vy: 10 }); // 10 <= MAX_STEP(12) → one step
+    resolvePlayerMovement(p, floorRow10);
+    expect(p.y).toBeCloseTo(240 - p.h - 0.01, 2);
+    expect(p.onGround).toBe(true);
+  });
+
+  it('stops against a wall when moving fast horizontally', () => {
+    const p = mk({ x: 0, vx: 300 });
+    resolvePlayerMovement(p, wallCol5);
+    expect(p.x).toBeCloseTo(120 - p.w - 0.01, 2);
+    expect(p.vx).toBe(0);
+  });
+
+  it('advances freely by exactly (vx, vy) with no solids', () => {
+    const p = mk({ vx: 7, vy: 9 });
+    resolvePlayerMovement(p, () => false);
+    expect(p.x).toBe(7);
+    expect(p.y).toBe(9);
+    expect(p.vx).toBe(7);
+    expect(p.vy).toBe(9);
+    expect(p.onGround).toBe(false);
+  });
+});


### PR DESCRIPTION
Fixes the last "physics feels broken" item: on long falls the player tunnels through thin floors / air pockets, because `resolveCollisions()` moved the full `vy` in one jump and only checked the destination cell.

## Approach
**Sweep** the movement in sub-steps of `TILE*0.5`, running the existing edge checks each sub-step — so no tile is ever skipped. **Fall speed stays uncapped** (respecting the deliberate gravity revamp); a flat `vy` cap was rejected because it would regress fast-falling. Slow movement (|v| ≤ half a tile) collapses to a single step, so normal play is byte-for-byte unchanged.

## Changes
- New `js/physics.ts` → `resolvePlayerMovement(player, isSolidAt)`: exact port of the old snapping logic in a sub-step loop. Takes `isSolidAt` as a param so it's pure/testable.
- `main.ts` calls it from `resolveCollisions()`.
- `test/physics.test.ts` (4 tests): `vy=300` no-tunnel regression, slow-fall parity, wall stop, free movement.

## Verified
- 34/34 tests, typecheck clean, build OK.
- In-browser: dropped the player from mid-air → landed exactly on the grass (`y=97.99`, `onGround=true`) and stayed put; did **not** fall through to the map bottom. No console errors.