### PR TITLE
Cut base player speed by 60% (0.3 -> 0.12)

### DIFF
--- a/js/player.ts
+++ b/js/player.ts
@@ -21,7 +21,7 @@ const BASE_PLAYER: Player = {
   staminaMax: 100,
   carryCap: 40,
   pickPower: 2,
-  speed: 0.3,
+  speed: 0.12,
   drill: 1,
   inventory: [],
   pages: {},
@@ -271,7 +271,7 @@ export function softReset() {
 
 export const upgrades: Record<string, Upgrade> = {
   pickaxe:  { key: 'pickPower', name: 'Pickaxe',           desc: 'Mine harder materials', step: 1,    max: 10,  base: 50,  scale: 1.6,  baseLevel: 0 },
-  boots:    { key: 'speed',     name: 'Boots',             desc: 'Move faster',          step: 0.10, max: 2.0, base: 80,  scale: 1.5,  baseLevel: 0.3 },
+  boots:    { key: 'speed',     name: 'Boots',             desc: 'Move faster',          step: 0.10, max: 2.0, base: 80,  scale: 1.5,  baseLevel: 0.12 },
   backpack: { key: 'carryCap',  name: 'Leather Backpack',  desc: 'Increase carry cap',   max: Infinity, base: 60,  scale: 5, baseLevel: 40 },
   lungs:    { key: 'staminaMax', name: 'Lung Expansion Pills', desc: 'Increase stamina',   step: 20,   max: Infinity, baseLevel: 100, price: level => 150 * Math.pow(level + 1, 1.3) },
   drill:    { key: 'drill',     name: 'Drill Expander',    desc: 'Mine more blocks',     step: 1,    max: 5,      baseLevel: 1,    price: level => (level + 1) * 500 }

--- a/test/player.test.ts
+++ b/test/player.test.ts
@@ -10,7 +10,7 @@ import {
 function resetPlayer() {
   Object.assign(player, {
     cash: 0, stamina: 100, staminaMax: 100, carryCap: 40,
-    pickPower: 2, speed: 0.3, drill: 1, forgeLevel: 0, ascensions: 0,
+    pickPower: 2, speed: 0.12, drill: 1, forgeLevel: 0, ascensions: 0,
   });
   player.inventory = [];
   player.forgeQueue = [];


### PR DESCRIPTION
Base movement felt too fast. Reduces `BASE_PLAYER.speed` **0.3 → 0.12** (a 60% cut), and keeps the Boots upgrade `baseLevel` in sync (0.3 → 0.12) so shop level/pricing math stays correct. Boots `step` (0.10) and `max` (2.0) unchanged.

Terminal horizontal speed drops from ~2.04 to ~0.82 px/frame.

34/34 tests pass (the boots-price test still expects $80 since base speed now equals the boots baseLevel), typecheck clean, build OK.

**Note:** existing saves keep their stored `speed` value (old base 0.3), so you'll need a Hard Reset (or an ascension) to feel the new base speed on your current save.